### PR TITLE
Clean up for hbck2 now that 2.1.1 is out

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -101,11 +101,12 @@ public class HBCK2 extends Configured implements Tool {
   }
 
   static void checkVersion(final String versionStr) {
-    if (versionStr.startsWith(TWO_POINT_ONE)) {
-      throw new UnsupportedOperationException(TWO_POINT_ONE + " has no support for hbck2");
-    }
     if (VersionInfo.compareVersion(MININUM_VERSION, versionStr) > 0) {
       throw new UnsupportedOperationException("Requires " + MININUM_VERSION + " at least.");
+    }
+    // except 2.1.0 didn't ship with support
+    if (VersionInfo.compareVersion(TWO_POINT_ONE, versionStr) == 0) {
+      throw new UnsupportedOperationException(TWO_POINT_ONE + " has no support for hbck2");
     }
   }
 

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCK2.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCK2.java
@@ -70,6 +70,11 @@ public class TestHBCK2 {
   }
 
   @Test
+  public void testCheckVersionSpecial210() {
+    HBCK2.checkVersion("2.1.0-patchedForHBCK2");
+  }
+
+  @Test
   public void testCheckVersion203() {
     HBCK2.checkVersion("2.0.3");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <compileSource>1.8</compileSource>
     <java.min.version>${compileSource}</java.min.version>
     <maven.min.version>3.3.3</maven.min.version>
-    <hbase.version>2.1.1-SNAPSHOT</hbase.version>
+    <hbase.version>2.1.1</hbase.version>
     <maven.compiler.version>3.6.1</maven.compiler.version>
     <surefire.version>2.21.0</surefire.version>
     <surefire.provider>surefire-junit47</surefire.provider>


### PR DESCRIPTION
* clean up the version checking so that folks can provide a patched version of 2.1.0 if needed
* rely on a released version so  that builds from clean checkout work