### PR TITLE
HBASE-22680 [HBCK2] OfflineMetaRepair for hbase2/hbck2

### DIFF
--- a/hbase-hbck2/pom.xml
+++ b/hbase-hbck2/pom.xml
@@ -177,6 +177,27 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.version}</version>
+      <scope>provided</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-zookeeper</artifactId>
+      <version>${hbase.version}</version>
+      <scope>provided</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase.version}</version>
+      <scope>provided</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-testing-util</artifactId>
       <version>${hbase.version}</version>
       <scope>test</scope>

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -274,11 +274,12 @@ public class HBCK2 extends Configured implements Tool {
     writer.println(" " + ASSIGNS + " [OPTIONS] <ENCODED_REGIONNAME>...");
     writer.println("   Options:");
     writer.println("    -o,--override  override ownership by another procedure");
-    writer.println("   A 'raw' assign that can be used even during Master initialization.");
-    writer.println("   Skirts Coprocessors. Pass one or more encoded RegionNames.");
-    writer.println("   1588230740 is the hard-coded name for the hbase:meta region and");
-    writer.println("   de00010733901a05f5a2a3a382e27dd4 is an example of what a user-space");
-    writer.println("   encoded Region name looks like. For example:");
+    writer.println("   A 'raw' assign that can be used even during Master initialization");
+    writer.println("   (if the -skip flag is specified). Skirts Coprocessors. Pass one");
+    writer.println("   or more encoded region names. 1588230740 is the hard-coded name");
+    writer.println("   for the hbase:meta region and de00010733901a05f5a2a3a382e27dd4 is");
+    writer.println("   an example of what a user-space encoded region name looks like.");
+    writer.println("   For example:");
     writer.println("     $ HBCK2 assign 1588230740 de00010733901a05f5a2a3a382e27dd4");
     writer.println("   Returns the pid(s) of the created AssignProcedure(s) or -1 if none.");
     writer.println();
@@ -286,7 +287,7 @@ public class HBCK2 extends Configured implements Tool {
     writer.println("   Options:");
     writer.println("    -o,--override   override if procedure is running/stuck");
     writer.println("    -r,--recursive  bypass parent and its children. SLOW! EXPENSIVE!");
-    writer.println("    -w,--lockWait   milliseconds to wait on lock before giving up; default=1");
+    writer.println("    -w,--lockWait   milliseconds to wait before giving up; default=1");
     writer.println("   Pass one (or more) procedure 'pid's to skip to procedure finish.");
     writer.println("   Parent of bypassed procedure will also be skipped to the finish.");
     writer.println("   Entities will be left in an inconsistent state and will require");
@@ -298,11 +299,12 @@ public class HBCK2 extends Configured implements Tool {
     writer.println(" " + UNASSIGNS + " <ENCODED_REGIONNAME>...");
     writer.println("   Options:");
     writer.println("    -o,--override  override ownership by another procedure");
-    writer.println("   A 'raw' unassign that can be used even during Master initialization.");
-    writer.println("   Skirts Coprocessors. Pass one or more encoded RegionNames:");
-    writer.println("   1588230740 is the hard-coded name for the hbase:meta region and");
-    writer.println("   de00010733901a05f5a2a3a382e27dd4 is an example of what a user-space");
-    writer.println("   encoded Region name looks like. For example:");
+    writer.println("   A 'raw' unassign that can be used even during Master initialization");
+    writer.println("   (if the -skip flag is specified). Skirts Coprocessors. Pass one or");
+    writer.println("   more encoded region names. 1588230740 is the hard-coded name for");
+    writer.println("   the hbase:meta region and de00010733901a05f5a2a3a382e27dd4 is an");
+    writer.println("   example of what a userspace encoded region name looks like.");
+    writer.println("   For example:");
     writer.println("     $ HBCK2 unassign 1588230740 de00010733901a05f5a2a3a382e27dd4");
     writer.println("   Returns the pid(s) of the created UnassignProcedure(s) or -1 if none.");
     writer.println();
@@ -312,27 +314,27 @@ public class HBCK2 extends Configured implements Tool {
     writer.println("   To read current table state, in the hbase shell run: ");
     writer.println("     hbase> get 'hbase:meta', '<TABLENAME>', 'table:state'");
     writer.println("   A value of \\x08\\x00 == ENABLED, \\x08\\x01 == DISABLED, etc.");
+    writer.println("   Can also run a 'describe \"<TABLENAME>\"' at the shell prompt.");
     writer.println("   An example making table name 'user' ENABLED:");
     writer.println("     $ HBCK2 setTableState users ENABLED");
     writer.println("   Returns whatever the previous table state was.");
     writer.println();
     writer.println(" " + SET_REGION_STATE + " <ENCODED_REGIONNAME> <STATE>");
-    writer.println("   Possible region states: " + Arrays.stream(RegionState.State.values()).
-      map(i -> i.toString()).collect(Collectors.joining(", ")));
+    writer.println("   Possible region states:");
+    writer.println("      " + Arrays.stream(RegionState.State.values()).map(i -> i.toString()).
+        collect(Collectors.joining(", ")));
     writer.println("   WARNING: This is a very risky option intended for use as last resort.");
-    writer.println("    Example scenarios are when unassigns/assigns can't move forward ");
-    writer.println("     due to region being in an inconsistent state in META. For example, ");
-    writer.println("     'unassigns' command can only proceed ");
-    writer.println("      if passed in region is in one of following states: ");
-    writer.println("                [SPLITTING|SPLIT|MERGING|OPEN|CLOSING]");
-    writer.println("   Before manually setting a region state with this command,");
-    writer.println("   please certify that this region is not being handled by");
-    writer.println("   by a running procedure, such as Assign or Split. You can get a view of ");
-    writer.println("   running procedures from hbase shell, using 'list_procedures' command. ");
-    writer.println("   An example setting region 'de00010733901a05f5a2a3a382e27dd4' to CLOSING:");
+    writer.println("   Example scenarios include unassigns/assigns that can't move forward");
+    writer.println("   because region is in an inconsistent state in 'hbase:meta'. For");
+    writer.println("   example, the 'unassigns' command can only proceed if passed a region");
+    writer.println("   in one of the following states: SPLITTING|SPLIT|MERGING|OPEN|CLOSING");
+    writer.println("   Before manually setting a region state with this command, please");
+    writer.println("   certify that this region is not being handled by a running procedure,");
+    writer.println("   such as 'assign' or 'split'. You can get a view of running procedures");
+    writer.println("   in the hbase shell using the 'list_procedures' command. An example");
+    writer.println("   setting region 'de00010733901a05f5a2a3a382e27dd4' to CLOSING:");
     writer.println("     $ HBCK2 setRegionState de00010733901a05f5a2a3a382e27dd4 CLOSING");
-    writer.println("   Returns \"0\" SUCCESS code if it informed region state is changed, "
-      + "\"1\" FAIL code otherwise.");
+    writer.println("   Returns \"0\" if region state changed and \"1\" otherwise.");
     writer.println();
 
     writer.close();
@@ -382,7 +384,8 @@ public class HBCK2 extends Configured implements Tool {
     options.addOption(peerPort);
     Option version = Option.builder("v").longOpt(VERSION).desc("this hbck2 version").build();
     options.addOption(version);
-    Option skip = Option.builder("s").longOpt("skip").desc("skip hbase version check").build();
+    Option skip = Option.builder("s").longOpt("skip").
+        desc("skip hbase version check/PleaseHoldException/Master initializing").build();
     options.addOption(skip);
 
     // Parse command-line.

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java.rej
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java.rej
@@ -1,0 +1,43 @@
+diff a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java	(rejected hunks)
+@@ -312,26 +314,27 @@ public class HBCK2 extends Configured implements Tool {
+     writer.println("   To read current table state, in the hbase shell run: ");
+     writer.println("     hbase> get 'hbase:meta', '<TABLENAME>', 'table:state'");
+     writer.println("   A value of \\x08\\x00 == ENABLED, \\x08\\x01 == DISABLED, etc.");
++    writer.println("   Can also run a 'describe \"<TABLENAME>\"' at the shell prompt.");
+     writer.println("   An example making table name 'user' ENABLED:");
+     writer.println("     $ HBCK2 setTableState users ENABLED");
+     writer.println("   Returns whatever the previous table state was.");
+     writer.println();
+     writer.println(" " + SET_REGION_STATE + " <ENCODED_REGIONNAME> <STATE>");
+-    writer.println("   Possible region states: " + Arrays.stream(RegionState.State.values()).
+-      map(i -> i.toString()).collect(Collectors.joining(", ")));
+-    writer.println("   WARNING: This is a very risky option intended for use as last resource.");
+-    writer.println("    Example scenarios for this is when unassings/assigns can't move forward ");
+-    writer.println("     due region being on an inconsistent state in META. For example, ");
+-    writer.println("     'unassigns' command can only proceed ");
+-    writer.println("      if passed in region is in one of following states: ");
+-    writer.println("                [SPLITTING|SPLIT|MERGING|OPEN|CLOSING]");
+-    writer.println("   Before manually setting a region state with this command,");
+-    writer.println("   please certify that this region is not being handled by");
+-    writer.println("   a running procedure, such as Assign or Split. You can get a view of ");
+-    writer.println("   running procedures from hbase shell, using 'list_procedures' command. ");
+-    writer.println("   An example setting region 'de00010733901a05f5a2a3a382e27dd4' to CLOSING:");
++    writer.println("   Possible region states:");
++    writer.println("      " + Arrays.stream(RegionState.State.values()).map(i -> i.toString()).
++        collect(Collectors.joining(", ")));
++    writer.println("   WARNING: This is a very risky option intended for use as last resort.");
++    writer.println("   Example scenarios include unassigns/assigns that can't move forward");
++    writer.println("   because region is in an inconsistent state in 'hbase:meta'. For");
++    writer.println("   example, the 'unassigns' command can only proceed if passed a region");
++    writer.println("   in one of the following states: SPLITTING|SPLIT|MERGING|OPEN|CLOSING");
++    writer.println("   Before manually setting a region state with this command, please");
++    writer.println("   certify that this region is not being handled by a running procedure,");
++    writer.println("   such as 'assign' or 'split'. You can get a view of running procedures");
++    writer.println("   in the hbase shell using the 'list_procedures' command. An example");
++    writer.println("   setting region 'de00010733901a05f5a2a3a382e27dd4' to CLOSING:");
+     writer.println("     $ HBCK2 setRegionState de00010733901a05f5a2a3a382e27dd4 CLOSING");
+-    writer.println("   Returns whatever the previous region state was.");
++    writer.println("   Returns \"0\" if region state changed and \"1\" otherwise.");
+     writer.println();
+ 
+     writer.close();


### PR DESCRIPTION
This commit checks-in hbck1 code with modifications under
a new package. Changes included here allow rebuild of meta
from filesystem meta data so the rebuilt hbase:meta works
for hbase2. This facility is exposed via the OfflineMetaRepair
tool with rebuild receipe outlined in the README documentation.
More of hbck1 to be exposed (or removed) in future commits to
address list of wants in parent issue HBASE-21745.

M README.md
 Updated usage. Edit of aspects. Added section on end on how
 to rebuild meta offline.

M pom.xml
 Use hbase testing utility code instead of repro in
 hbck as hbck1 used to do.

M hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
 Updated the usage.

A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsck.java
A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsckRepair.java
 Copied from hbck1 and updated to work against hbase2.
 Most goes unused. Subsequent commits will amend/expose/purge
 this class. For now the rebuild meta function is all that is
 used. Some new code added to make it work with hbase2.
 Some code removed and hbasetestingutility equivalents used
 instead.

A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/ReplicationChecker.java
A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/TableIntegrityErrorHandler.java
A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/TableIntegrityErrorHandlerImpl.java
 Unmodified except for repackaging.

A hbase-hbck2/src/main/java/org/apache/hbase/hbck1/OfflineMetaRepair.java
 Tool that exposes meta fixup. Some cleanup from original.