### PR TITLE
HBASE-22674 precommit docker image installs JRE over JDK

### DIFF
--- a/dev-support/Dockerfile
+++ b/dev-support/Dockerfile
@@ -22,15 +22,11 @@ FROM maven:3.6-jdk-8
 # hadolint ignore=DL3008
 RUN apt-get -q update && apt-get -q install --no-install-recommends -y \
        git \
-       bats \
-       findbugs \
        rsync \
        shellcheck \
        wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-ENV FINDBUGS_HOME /usr
 
 ###
 # Avoid out of memory errors in builds


### PR DESCRIPTION
* remove findbugs because it pulls in a JRE
* remove bats because we don't use it.