### PR TITLE
HBASE-22688 [HBCK2] Add filesystem fixup to hbck2

### DIFF
--- a/hbase-hbck2/README.md
+++ b/hbase-hbck2/README.md
@@ -385,3 +385,7 @@ The rebuild of _hbase:meta_ adds the user tables in _DISABLED_ state and the reg
 Do it one-at-a-time or see the `enable_all ".*"` command to enable all tables in one shot.
 
 The rebuild meta will likely be missing edits and may need subsequent repair and cleaning using facility outlined higher up in this README.
+
+### Dropped reference files, missing hbase.version file, and corrupted hfiles
+
+HBCK2 can check for hanging references and corrupt hfiles. You can ask it to sideline bad files which may be needed to get over humps where regions won't online or reads are failing. See the _filesystem_ command in the HBCK2 listing. Pass one or more tablename (or 'none' to check all tables). It will report bad files. Pass the _--fix_ option to effect repairs.

--- a/hbase-hbck2/src/main/java/org/apache/hbase/FileSystemFsck.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/FileSystemFsck.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hbase;
 
-import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLineParser;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.DefaultParser;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.Option;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.Options;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.ParseException;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -30,11 +29,12 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hbase.hbck1.HBaseFsck;
 import org.apache.hbase.hbck1.HFileCorruptionChecker;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.stream.Collectors;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLineParser;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.DefaultParser;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Option;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Options;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.ParseException;
 
 /**
  * Checks and repairs for hbase filesystem.
@@ -59,7 +59,7 @@ public class FileSystemFsck implements Closeable {
   int fsck(Options hbck2Options, String[] args) throws IOException {
     Options options = new Options();
     Option fixOption = Option.builder("f").longOpt("fix").build();
-      options.addOption(fixOption);
+    options.addOption(fixOption);
     // Parse command-line.
     CommandLineParser parser = new DefaultParser();
     CommandLine commandLine;

--- a/hbase-hbck2/src/main/java/org/apache/hbase/FileSystemFsck.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/FileSystemFsck.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hbase;
+
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLineParser;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.DefaultParser;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Option;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Options;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.hbase.hbck1.HBaseFsck;
+import org.apache.hbase.hbck1.HFileCorruptionChecker;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Checks and repairs for hbase filesystem.
+ */
+public class FileSystemFsck implements Closeable {
+  private final Configuration configuration;
+  private FileSystem fs;
+  private Path rootDir;
+
+  FileSystemFsck(Configuration conf) throws IOException {
+    this.configuration = conf;
+    this.rootDir = FSUtils.getRootDir(this.configuration);
+    this.fs = rootDir.getFileSystem(this.configuration);
+
+  }
+
+  @Override
+  public void close() {
+    // Nothing to do.
+  }
+
+  int fsck(Options hbck2Options, String[] args) throws IOException {
+    Options options = new Options();
+    Option fixOption = Option.builder("f").longOpt("fix").build();
+      options.addOption(fixOption);
+    // Parse command-line.
+    CommandLineParser parser = new DefaultParser();
+    CommandLine commandLine;
+    try {
+      commandLine = parser.parse(options, args, false);
+    } catch(ParseException e) {
+      HBCK2.usage(hbck2Options, e.getMessage());
+      return -1;
+    }
+    boolean fix = commandLine.hasOption(fixOption.getOpt());
+    // Before we start make sure of the version file.
+    if (fix && !HBaseFsck.versionFileExists(this.fs, this.rootDir)) {
+      HBaseFsck.versionFileCreate(this.configuration, this.fs, this.rootDir);
+    }
+    // Iterate over list of tablenames or encoded region names passed.
+    try (HBaseFsck hbaseFsck = new HBaseFsck(this.configuration)) {
+      // Check hfiles.
+      HFileCorruptionChecker hfcc = hbaseFsck.createHFileCorruptionChecker(fix);
+      hbaseFsck.setHFileCorruptionChecker(hfcc);
+      Collection<String> tables = commandLine.getArgList();
+      Collection<Path> tableDirs = tables.isEmpty()?
+          FSUtils.getTableDirs(this.fs, this.rootDir):
+          tables.stream().map(t -> FSUtils.getTableDir(this.rootDir, TableName.valueOf(t))).
+              collect(Collectors.toList());
+      hfcc.checkTables(tableDirs);
+      hfcc.report(hbaseFsck.getErrors());
+      // Now check links.
+      hbaseFsck.setFixReferenceFiles(fix);
+      hbaseFsck.setFixHFileLinks(fix);
+      hbaseFsck.setShouldRerun();
+      hbaseFsck.offlineHbck();
+    } catch (ClassNotFoundException | InterruptedException e) {
+      throw new IOException(e);
+    }
+    return 0;
+  }
+}

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -296,8 +296,10 @@ public class HBCK2 extends Configured implements Tool {
     writer.println("   you have is a parent pid to finish parent and children. This");
     writer.println("   is SLOW, and dangerous so use selectively. Does not always work.");
     writer.println();
-    // out.println("   -checkCorruptHFiles     Check all Hfiles by opening them to make sure they are valid");
-    // out.println("   -sidelineCorruptHFiles  Quarantine corrupted HFiles.  implies -checkCorruptHFiles");
+    // out.println("   -checkCorruptHFiles     Check all Hfiles by opening them to make
+    // sure they are valid");
+    // out.println("   -sidelineCorruptHFiles  Quarantine corrupted HFiles.  implies
+    // -checkCorruptHFiles");
     // out.println("   -fixVersionFile   Try to fix missing hbase.version file in hdfs.");
     // out.println("   -fixReferenceFiles  Try to offline lingering reference store files");
     // out.println("   -fixHFileLinks  Try to offline lingering HFileLinks");

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
@@ -508,14 +508,14 @@ public class HFileCorruptionChecker {
    * Print a human readable summary of hfile quarantining operations.
    */
   public void report(HBaseFsck.ErrorReporter out) {
-    out.print("Checked " + hfilesChecked.get() + " hfile for corruption");
-    out.print("  HFiles corrupted:                  " + corrupted.size());
+    out.print("Checked " + hfilesChecked.get() + " hfiles for corruption");
+    out.print("  Corrupt HFiles:                    " + corrupted.size());
     if (inQuarantineMode) {
-      out.print("    HFiles successfully quarantined: " + quarantined.size());
+      out.print("    Successfully Quarantined HFiles: " + quarantined.size());
       for (Path sq : quarantined) {
         out.print("      " + sq);
       }
-      out.print("    HFiles failed quarantine:        " + failures.size());
+      out.print("    Failed Quarantine HFiles:        " + failures.size());
       for (Path fq : failures) {
         out.print("      " + fq);
       }
@@ -529,18 +529,26 @@ public class HFileCorruptionChecker {
     String fixedState = (corrupted.size() == quarantined.size()) ? "OK"
         : "CORRUPTED";
 
-    // print mob-related report
     if (inQuarantineMode) {
-      out.print("    Mob files successfully quarantined: " + quarantinedMobFiles.size());
+      out.print("Summary:     " + initialState + " => " + fixedState);
+    } else {
+      out.print("Summary:     " + initialState);
+    }
+
+    // print mob-related report
+    out.print("Checked " + mobFilesChecked.get() + " MOB files for corruption");
+    out.print("  Corrupt MOB files:                 " + corruptedMobFiles.size());
+    if (inQuarantineMode) {
+      out.print("    Successfully Quarantined MOB files: " + quarantinedMobFiles.size());
       for (Path sq : quarantinedMobFiles) {
         out.print("      " + sq);
       }
-      out.print("    Mob files failed quarantine:        " + failureMobFiles.size());
+      out.print("    Failed Quarantine MOB files:        " + failureMobFiles.size());
       for (Path fq : failureMobFiles) {
         out.print("      " + fq);
       }
     }
-    out.print("    Mob files moved while checking:     " + missedMobFiles.size());
+    out.print("    MOB files moved while checking:  " + missedMobFiles.size());
     for (Path mq : missedMobFiles) {
       out.print("      " + mq);
     }
@@ -549,11 +557,9 @@ public class HFileCorruptionChecker {
         : "CORRUPTED";
 
     if (inQuarantineMode) {
-      out.print("Summary: " + initialState + " => " + fixedState);
-      out.print("Mob summary: " + initialMobState + " => " + fixedMobState);
+      out.print("MOB summary: " + initialMobState + " => " + fixedMobState);
     } else {
-      out.print("Summary: " + initialState);
-      out.print("Mob summary: " + initialMobState);
+      out.print("MOB summary: " + initialMobState);
     }
   }
 }


### PR DESCRIPTION
Adds a general filesystem check command to the HBCK2 list.
Runs just the offline filesystem checks from the old hbck1
HBaseFsck tool. Checks hfile validity, if references and
hfile links are wholesome, and whether the hbase.version
file is present. Pass '--fix' to do fixup.

Depends on hbck1 HBaseFsck being present in hbck2
(HBASE-22680 adds it so this could go in after it)

Does NOT do regiondir or tabledir fixup or fixing of
orphans in hdfs or plugging holes in hdfs.

A hbase-hbck2/src/main/java/org/apache/hbase/FileSystemFsck.java
 Adds a file to handle filesystem fsck checking and fixing.

M hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
 Formatting fixes and filling out the MOB report so like the hfile
 report.

Signed-off-by: Sean Busbey <busbey@apache.org>