### PR TITLE
HBASE-22952 HBCK2 replication command is incompatible with 2.0.x

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -566,7 +566,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
 
       case REPLICATION:
         try (ClusterConnection connection = connect()) {
-          checkHBCKSupport(connection, command);
+          checkHBCKSupport(connection, command, "2.1.1", "2.2.0", "3.0.0");
           try (ReplicationFsck replicationFsck = new ReplicationFsck(getConf())) {
             if (replicationFsck.fsck(purgeFirst(commands)) != 0) {
               return EXIT_FAILURE;


### PR DESCRIPTION
Adds supported versions to the `replication` command.