### PR TITLE
HBASE-23002 [HBCK2/hbase-operator-tools] Create an assembly that buil…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,90 @@
+# HBASE Operator Tools Changelog
+
+<!---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be careful doing manual edits in this file. Do not change format
+# of release header or remove the below marker. This file is generated.
+# DO NOT REMOVE THIS MARKER; FOR INTERPOLATING CHANGES!-->
+## Release hbase-operator-tools-1.0.0 - Unreleased (as of 2019-09-12)
+
+
+
+### NEW FEATURES:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-22183](https://issues.apache.org/jira/browse/HBASE-22183) | [hbck2] Update hbck2 README to explain new "setRegionState" method. |  Minor | documentation, hbck2 |
+| [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | HBCK2 setRegionState command |  Minor | hbase-operator-tools, hbck2 |
+
+
+### IMPROVEMENTS:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-22999](https://issues.apache.org/jira/browse/HBASE-22999) | Fix non-varargs compile warnings |  Minor | hbase-operator-tools |
+
+
+### BUG FIXES:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-22951](https://issues.apache.org/jira/browse/HBASE-22951) | [HBCK2] hbase hbck throws IOE "No FileSystem for scheme: hdfs" |  Major | documentation, hbck2 |
+| [HBASE-22952](https://issues.apache.org/jira/browse/HBASE-22952) | HBCK2 replication command is incompatible with 2.0.x |  Critical | hbase-operator-tools |
+| [HBASE-22949](https://issues.apache.org/jira/browse/HBASE-22949) | [HBCK2] Add lang3 as explicit dependency |  Major | . |
+| [HBASE-22687](https://issues.apache.org/jira/browse/HBASE-22687) | [hbase-operator-tools] Add checkstyle plugin and configs from hbase |  Major | . |
+| [HBASE-22674](https://issues.apache.org/jira/browse/HBASE-22674) | precommit docker image installs JRE over JDK (multiple repos) |  Critical | build, hbase-connectors |
+| [HBASE-21763](https://issues.apache.org/jira/browse/HBASE-21763) | [HBCK2] hbck2 options does not work and throws exceptions |  Minor | hbck2 |
+| [HBASE-21484](https://issues.apache.org/jira/browse/HBASE-21484) | [HBCK2] hbck2 should default to a released hbase version |  Major | hbck2 |
+| [HBASE-21483](https://issues.apache.org/jira/browse/HBASE-21483) | [HBCK2] version string checking should look for exactly the version we know doesn't work |  Major | hbck2 |
+| [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | [hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized) |  Major | hbase-operator-tools, hbck2 |
+
+
+### TESTS:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-21353](https://issues.apache.org/jira/browse/HBASE-21353) | TestHBCKCommandLineParsing#testCommandWithOptions hangs on call to HBCK2#checkHBCKSupport |  Major | hbase-operator-tools, hbck2 |
+
+
+### SUB-TASKS:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | Move to SLF4J |  Major | hbase-operator-tools |
+| [HBASE-22998](https://issues.apache.org/jira/browse/HBASE-22998) | Fix NOTICE and LICENSE |  Blocker | hbase-operator-tools |
+| [HBASE-22825](https://issues.apache.org/jira/browse/HBASE-22825) | [HBCK2] Add a client-side to hbase-operator-tools that can exploit fixMeta added in server side |  Major | hbck2 |
+| [HBASE-22957](https://issues.apache.org/jira/browse/HBASE-22957) | [HBCK2] reference file check fails if compiled with old version but check against new |  Major | . |
+| [HBASE-22865](https://issues.apache.org/jira/browse/HBASE-22865) | [HBCK2] shows the whole help/usage message after the error message |  Minor | hbck2 |
+| [HBASE-22843](https://issues.apache.org/jira/browse/HBASE-22843) | [HBCK2] Fix HBCK2 after HBASE-22777 & HBASE-22758 |  Blocker | hbase-operator-tools |
+| [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | [HBCK2] Expose replication fixes from hbck1 |  Major | . |
+| [HBASE-22713](https://issues.apache.org/jira/browse/HBASE-22713) | [HBCK2] Add hdfs integrity report to 'filesystem' command |  Major | hbck2 |
+| [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | Add an API  ScheduleSCP() to HBCK2 |  Major | hbase-operator-tools, hbck2 |
+| [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | [HBCK2] Add filesystem fixup to hbck2 |  Major | hbck2 |
+| [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | [HBCK2] OfflineMetaRepair for hbase2/hbck2 |  Major | hbck2 |
+
+
+### OTHER:
+
+| JIRA | Summary | Priority | Component |
+|:---- |:---- | :--- |:---- |
+| [HBASE-19121](https://issues.apache.org/jira/browse/HBASE-19121) | HBCK for AMv2 (A.K.A HBCK2) |  Major | hbck, hbck2 |
+| [HBASE-22906](https://issues.apache.org/jira/browse/HBASE-22906) | Clean up checkstyle complaints in hbase-operator-tools |  Trivial | hbase-operator-tools |
+| [HBASE-22675](https://issues.apache.org/jira/browse/HBASE-22675) | Use commons-cli from hbase-thirdparty |  Major | hbase-operator-tools |
+| [HBASE-21433](https://issues.apache.org/jira/browse/HBASE-21433) | [hbase-operator-tools] Add Apache Yetus integration for hbase-operator-tools repository |  Major | build, hbase-operator-tools |
+
+

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,1228 @@
+# RELEASENOTES
+
+<!---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be careful doing manual edits in this file. Do not change format
+# of release header or remove the below marker. This file is generated.
+# DO NOT REMOVE THIS MARKER; FOR INTERPOLATING CHANGES!-->
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+
+# HBASE  hbase-operator-tools-1.0.0 Release Notes
+
+These release notes cover new developer and user-facing incompatibilities, important issues, features, and major improvements.
+
+
+---
+
+* [HBASE-22997](https://issues.apache.org/jira/browse/HBASE-22997) | *Major* | **Move to SLF4J**
+
+Added SLF4J binding for LOG4J 2.
+
+
+---
+
+* [HBASE-22717](https://issues.apache.org/jira/browse/HBASE-22717) | *Major* | **[HBCK2] Expose replication fixes from hbck1**
+
+Adds 'replication' command to HBCK2. Will clear old deleted peer queues and if a table name is passed, can clear replication barrier flags.
+
+Exposes the old hbck1 code that did this.
+
+
+---
+
+* [HBASE-21393](https://issues.apache.org/jira/browse/HBASE-21393) | *Major* | **Add an API  ScheduleSCP() to HBCK2**
+
+Adds scheduleRecoveries verb to HBCK2 tool for scheduling ServerCrashProcedures.
+
+Also adds a version checker and a refactor so we check version before trying a command (unless --skip is passed on command-line).
+
+
+---
+
+* [HBASE-22688](https://issues.apache.org/jira/browse/HBASE-22688) | *Major* | **[HBCK2] Add filesystem fixup to hbck2**
+
+Adds a 'filesystem' command to HBCK2. Checks for bad references, links, and corrupt hfiles with the option of sidelining if pass --fix option.
+
+
+---
+
+* [HBASE-22680](https://issues.apache.org/jira/browse/HBASE-22680) | *Major* | **[HBCK2] OfflineMetaRepair for hbase2/hbck2**
+
+Adds a version of the old OfflineMetaRepair tool from hbck1 updated to work against hbase2. Here is how you'd run it:
+
+ $ HBASE\_CLASSPATH\_PREFIX=~/checkouts/hbase-operator-tools/hbase-hbck2/target/hbase-hbck2-1.0.0-SNAPSHOT.jar ./bin/hbase org.apache.hbase.hbck1.OfflineMetaRepair -details
+
+See section "hbase:meta region/table restore/rebuild" in hbase-hbck README in operator tools for more detail on how to run it (https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)
+
+
+---
+
+* [HBASE-22143](https://issues.apache.org/jira/browse/HBASE-22143) | *Minor* | **HBCK2 setRegionState command**
+
+Adds a new feature to HBCK2: setRegionState.
+
+Given the encoded name of a Region, this command allows you to change the state of that Region recorded in Meta.
+
+
+---
+
+* [HBASE-21378](https://issues.apache.org/jira/browse/HBASE-21378) | *Major* | **[hbck2] add --skip version check to hbck2 tool (checkHBCKSupport blocks assigning hbase:meta or hbase:namespace when master is not initialized)**
+
+Adds a general -s,--skip option to hbck2 so you can run the command it first checking it is version compatible.
+
+Should not be needed going forward but in the spirt of our not knowing all the conditions under which we'll be trying to run hbck2, adding it.
+
+
+

--- a/hbase-hbck2/pom.xml
+++ b/hbase-hbck2/pom.xml
@@ -22,12 +22,11 @@
   -->
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.hbase</groupId>
+    <groupId>org.apache.hbase.operator.tools</groupId>
     <artifactId>hbase-operator-tools</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-
   <artifactId>hbase-hbck2</artifactId>
   <name>Apache HBase - HBCK2</name>
   <description>HBCK for HBase 2+</description>
@@ -209,10 +208,6 @@
       <artifactId>hbase-testing-util</artifactId>
       <version>${hbase.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hbase-operator-tools-assembly/pom.xml
+++ b/hbase-operator-tools-assembly/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements.  See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership.  The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+    -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hbase.operator.tools</groupId>
+    <artifactId>hbase-operator-tools</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>hbase-operator-tools-assembly</artifactId>
+  <name>Apache HBase Operator Tools - Assembly</name>
+  <description>
+        Module that does hbase-operator-tools assembly and that is all that it does.
+        We have a dedicated module just for assembly because of
+        http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries
+    </description>
+  <packaging>pom</packaging>
+  <properties>
+    <license.bundles.dependencies>true</license.bundles.dependencies>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <!--Else will use hbase-assembly as final name.-->
+          <finalName>${project.parent.artifactId}-${project.version}</finalName>
+          <skipAssembly>false</skipAssembly>
+          <appendAssemblyId>true</appendAssemblyId>
+          <tarLongFileMode>posix</tarLongFileMode>
+          <descriptors>
+            <descriptor>src/main/assembly/bin.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase.operator.tools</groupId>
+      <artifactId>hbase-hbck2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/hbase-operator-tools-assembly/src/main/assembly/bin.xml
+++ b/hbase-operator-tools-assembly/src/main/assembly/bin.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <!--
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements.  See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership.  The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+    -->
+  <id>bin</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <moduleSets>
+    <moduleSet>
+
+      <!-- Enable access to all projects in the current multimodule build! -->
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <!-- Now, select which projects to include in this module-set. -->
+      <includes>
+        <include>org.apache.hbase.operator.tools:hbase-hbck2</include>
+      </includes>
+      <sources>
+        <fileSets>
+          <fileSet>
+            <excludes>
+              <exclude>src/**</exclude>
+            </excludes>
+            <includes>
+              <include>README.md</include>
+            </includes>
+          </fileSet>
+        </fileSets>
+      </sources>
+      <binaries>
+        <outputDirectory>hbase-hbck2/</outputDirectory>
+        <unpack>false</unpack>
+        <dependencySets>
+          <dependencySet>
+            <excludes>
+              <exclude>org.slf4j:slf4j-api</exclude>
+            </excludes>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+  <!-- Include the generated LICENSE and NOTICE files -->
+  <files>
+    <file>
+      <source>${project.parent.basedir}/LICENSE.txt</source>
+      <outputDirectory>.</outputDirectory>
+      <destName>LICENSE.txt</destName>
+      <lineEnding>unix</lineEnding>
+    </file>
+    <file>
+      <source>${project.parent.basedir}/NOTICE.txt</source>
+      <outputDirectory>.</outputDirectory>
+      <destName>NOTICE.txt</destName>
+      <lineEnding>unix</lineEnding>
+    </file>
+    <file>
+      <source>${project.parent.basedir}/RELEASENOTES.md</source>
+      <outputDirectory>.</outputDirectory>
+      <destName>RELEASENOTES.md</destName>
+      <lineEnding>unix</lineEnding>
+    </file>
+    <file>
+      <source>${project.parent.basedir}/CHANGES.md</source>
+      <outputDirectory>.</outputDirectory>
+      <destName>CHANGES.md</destName>
+      <lineEnding>unix</lineEnding>
+    </file>
+    <file>
+      <source>${project.parent.basedir}/README.md</source>
+      <outputDirectory>.</outputDirectory>
+      <destName>README.md</destName>
+      <lineEnding>unix</lineEnding>
+    </file>
+  </files>
+</assembly>
+

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <relativePath/>
     <!-- no parent resolution -->
   </parent>
-  <groupId>org.apache.hbase</groupId>
+  <groupId>org.apache.hbase.operator.tools</groupId>
   <artifactId>hbase-operator-tools</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <name>Apache HBase Operator Tools</name>
@@ -55,6 +55,9 @@
   </licenses>
   <modules>
     <module>hbase-hbck2</module>
+    <!--Add an assembly module because of http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries
+         -->
+    <module>hbase-operator-tools-assembly</module>
   </modules>
   <scm>
     <connection>scm:git:git://gitbox.apache.org/repos/asf/hbase-operator-tools.git</connection>
@@ -146,6 +149,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase.operator.tools</groupId>
+        <artifactId>hbase-hbck2</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -296,10 +304,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-        <plugin>
           <!-- Approach followed here is roughly the same as mentioned here:
           https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/multi-module-config.html
           -->
@@ -392,6 +396,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <!--Defer to the hbase-assembly sub-module. It does all assembly.
+               We have dedicated assembly module because of
+               http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#module-binaries
+               -->
+          <skipAssembly>true</skipAssembly>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
…ds an hbase-operator-tools tgz

Add an hbase-assembly that is just for creating assemblies.
Also changed groupid from org.apache.hbase to
org.apache.hbase.operator.tools so lands into a different area in
repository -- less crowded, easier to differentiate from core
hbase.

Creates a bin assembly (src is made elsewhere in release script).
Adds a first-cut at RELEASENOTES and CHANGES (release script will
fix up what is here based off what is in JIRA to make it suit
the 1.0.0RC0)