### PR TITLE
HBASE-23018 - [HBCK2] Add useful messages when report/fixing missing regions in meta

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -219,6 +219,12 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
       try(ClusterConnection conn = connect();
         final Admin admin = conn.getAdmin()) {
         Map<TableName,List<Path>> report = reportTablesWithMissingRegionsInMeta(nameSpaceOrTable);
+        if(report.size() < 1) {
+          LOG.info("\nNo missing regions in meta are found. Worth using reportMissingRegionsInMeta first.\n" +
+                  "You are likely passing non-existent namespace or table. Note that table names should " +
+                  "include the namespace portion even for tables in the default namespace. " +
+                  "See also the command usage.\n");
+        }
         for (TableName tableName : report.keySet()) {
           if(admin.tableExists(tableName)) {
             futures.add(executorService.submit(new Callable<List<String>>() {
@@ -786,6 +792,12 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
 
   private String formatMissingRegionsInMetaReport(Map<TableName,List<Path>> report) {
     final StringBuilder builder = new StringBuilder();
+    if(report.size() < 1) {
+      builder.append("\nNo reports are found. You are likely passing non-existent " +
+              "namespace or table. Note that table names should include the namespace " +
+              "portion even for tables in the default namespace. See also the command usage.\n");
+      return builder.toString();
+    }
     builder.append("Missing Regions for each table:\n\t");
     report.keySet().stream().forEach(table -> {
       builder.append(table);

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -220,9 +220,10 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
         final Admin admin = conn.getAdmin()) {
         Map<TableName,List<Path>> report = reportTablesWithMissingRegionsInMeta(nameSpaceOrTable);
         if(report.size() < 1) {
-          LOG.info("\nNo missing regions in meta are found. Worth using reportMissingRegionsInMeta first.\n" +
-                  "You are likely passing non-existent namespace or table. Note that table names should " +
-                  "include the namespace portion even for tables in the default namespace. " +
+          LOG.info("\nNo missing regions in meta are found. Worth using " +
+                  "reportMissingRegionsInMeta first.\nYou are likely passing non-existent " +
+                  "namespace or table. Note that table names should include the namespace " +
+                  "portion even for tables in the default namespace. " +
                   "See also the command usage.\n");
         }
         for (TableName tableName : report.keySet()) {


### PR DESCRIPTION
Informing the user that

- No missing regions found in meta
- Likely a table name is passed without the NS portion
- See also the command usage

when executing reportMissingRegionsInMeta or addFsRegionsMissingInMeta.