### PR TITLE
HBASE-24571 HBCK2 fix addFsRegionsMissingInMeta to add regions in CLO…

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCKMetaTableAccessor.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCKMetaTableAccessor.java
@@ -457,7 +457,7 @@ public final class HBCKMetaTableAccessor {
     return put;
   }
 
-  private static Put addRegionStateToPut(Put put, RegionState.State state) throws IOException {
+  private static void addRegionStateToPut(Put put, RegionState.State state) throws IOException {
     put.add(CellBuilderFactory.create(CellBuilderType.SHALLOW_COPY)
       .setRow(put.getRow())
       .setFamily(HConstants.CATALOG_FAMILY)
@@ -466,7 +466,6 @@ public final class HBCKMetaTableAccessor {
       .setType(Cell.Type.Put)
       .setValue(Bytes.toBytes(state.name()))
       .build());
-    return put;
   }
 
   /**


### PR DESCRIPTION
…SED state again

This PR fix implementation of HBCKMetaTableAccessor.addRegionToMeta to insert new regions with CLOSED state, and also adds extra checks for this behaviour on both TestHBCKMetaTableAccessor and TestFsRegionsMetaRecoverer UTs.