### PR TITLE
HBASE-24778 [hbase-operator-tools] Merging regions failed when the table is not default namespace

### DIFF
--- a/hbase-tools/src/main/java/org/apache/hbase/RegionsMerger.java
+++ b/hbase-tools/src/main/java/org/apache/hbase/RegionsMerger.java
@@ -90,7 +90,7 @@ public class RegionsMerger extends Configured implements org.apache.hadoop.util.
     Path basePath = new Path(conf.get(HConstants.HBASE_DIR));
     basePath = new Path(basePath, "data");
     Path tablePath = new Path(basePath, table.getNamespaceAsString());
-    return new Path(tablePath, table.getNameAsString());
+    return new Path(tablePath, table.getQualifierAsString());
   }
 
   private long sumSizeInFS(Path parentPath) throws IOException {

--- a/hbase-tools/src/test/java/org/apache/hbase/TestRegionsMerger.java
+++ b/hbase-tools/src/test/java/org/apache/hbase/TestRegionsMerger.java
@@ -70,13 +70,11 @@ public class TestRegionsMerger {
   public void testMergeRegionsCanMergeToTarget() throws Exception {
     final int originalCount = TEST_UTIL.countRows(table);
     TEST_UTIL.getConfiguration().setInt(RegionsMerger.MAX_ROUNDS_IDLE, 10);
-    RegionsMerger merger = new RegionsMerger(TEST_UTIL.getConfiguration());
     // hbase-2.3 and hbase-2.1 merge's work differently; 2.3 won't merge if a merge candidate is a parent.
     // The below used to merge until only 3 regions. Made it less aggressive. Originally there are 15 regions.
     // Merge till 10.
     final int target = 10;
-    merger.mergeRegions(TABLE_NAME.getNameWithNamespaceInclAsString(), target);
-    List<RegionInfo> result = TEST_UTIL.getAdmin().getRegions(TABLE_NAME);
+    List<RegionInfo> result = mergeRegionsToTarget(TABLE_NAME, target);
     assertEquals(target, result.size());
     assertEquals("Row count before and after merge should be equal",
         originalCount, TEST_UTIL.countRows(table));
@@ -89,13 +87,8 @@ public class TestRegionsMerger {
       TEST_UTIL.getAdmin().createNamespace(NamespaceDescriptor.create(NAMESPACE).build());
       Table tableWithNamespace = TEST_UTIL.createMultiRegionTable(TABLE_NAME_WITH_NAMESPACE, family, 15);
       final int originalCount = TEST_UTIL.countRows(tableWithNamespace);
-      RegionsMerger merger = new RegionsMerger(TEST_UTIL.getConfiguration());
-      // hbase-2.3 and hbase-2.1 merge's work differently; 2.3 won't merge if a merge candidate is a parent.
-      // The below used to merge until only 3 regions. Made it less aggressive. Originally there are 15 regions.
-      // Merge till 10.
       final int target = 10;
-      merger.mergeRegions(TABLE_NAME_WITH_NAMESPACE.getNameWithNamespaceInclAsString(), target);
-      List<RegionInfo> result = TEST_UTIL.getAdmin().getRegions(TABLE_NAME_WITH_NAMESPACE);
+      List<RegionInfo> result = mergeRegionsToTarget(TABLE_NAME_WITH_NAMESPACE, target);
       assertEquals(target, result.size());
       assertEquals("Row count before and after merge should be equal",
         originalCount, TEST_UTIL.countRows(tableWithNamespace));
@@ -105,14 +98,13 @@ public class TestRegionsMerger {
     }
   }
 
+
   @Test
   public void testMergeRegionsCanMergeSomeButNotToTarget() throws Exception {
     TEST_UTIL.getConfiguration().setInt(RegionsMerger.MAX_ROUNDS_IDLE, 3);
-    RegionsMerger merger = new RegionsMerger(TEST_UTIL.getConfiguration());
     generateTableData();
     final int originalCount = TEST_UTIL.countRows(table);
-    merger.mergeRegions(TABLE_NAME.getNameWithNamespaceInclAsString(), 3);
-    List<RegionInfo> result = TEST_UTIL.getAdmin().getRegions(TABLE_NAME);
+    List<RegionInfo> result = mergeRegionsToTarget(TABLE_NAME, 3);
     assertEquals(8, result.size());
     assertEquals("Row count before and after merge should be equal",
         originalCount, TEST_UTIL.countRows(table));
@@ -122,12 +114,10 @@ public class TestRegionsMerger {
   public void testMergeRegionsCannotMergeAny() throws Exception {
     TEST_UTIL.getConfiguration().setDouble(RegionsMerger.RESULTING_REGION_UPPER_MARK, 0.5);
     TEST_UTIL.getConfiguration().setInt(RegionsMerger.MAX_ROUNDS_IDLE, 2);
-    RegionsMerger merger = new RegionsMerger(TEST_UTIL.getConfiguration());
     generateTableData();
     TEST_UTIL.getAdmin().flush(TABLE_NAME);
     final int originalCount = TEST_UTIL.countRows(table);
-    merger.mergeRegions(TABLE_NAME.getNameWithNamespaceInclAsString(), 3);
-    List<RegionInfo> result = TEST_UTIL.getAdmin().getRegions(TABLE_NAME);
+    List<RegionInfo> result = mergeRegionsToTarget(TABLE_NAME, 3);
     assertEquals(15, result.size());
     assertEquals("Row count before and after merge should be equal",
         originalCount, TEST_UTIL.countRows(table));
@@ -153,5 +143,11 @@ public class TestRegionsMerger {
         throw new Error("Failed to put row");
       }
     });
+  }
+
+  private List<RegionInfo> mergeRegionsToTarget(TableName tableName, int target) throws Exception {
+    RegionsMerger merger = new RegionsMerger(TEST_UTIL.getConfiguration());
+    merger.mergeRegions(tableName.getNameWithNamespaceInclAsString(), target);
+    return TEST_UTIL.getAdmin().getRegions(tableName);
   }
 }


### PR DESCRIPTION
[HBASE-24778](https://issues.apache.org/jira/browse/HBASE-24778)