### PR TITLE
HBASE-25921 Fix Wrong FileSystem when running `filesystem` on non-HDFS storage

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsUtils.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsUtils.java
@@ -56,13 +56,6 @@ public final class HBCKFsUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(HBCKFsUtils.class);
 
-  /** Parameter name for HBase WAL directory */
-  public static final String HBASE_WAL_DIR = "hbase.wal.dir";
-
-  /** Parameter to disable stream capability enforcement checks */
-  public static final String UNSAFE_STREAM_CAPABILITY_ENFORCE =
-      "hbase.unsafe.stream.capability.enforce";
-
   /**
    * Private constructor to keep this class from being instantiated.
    */
@@ -121,46 +114,6 @@ public final class HBCKFsUtils {
    */
   public static FileSystem getCurrentFileSystem(Configuration conf) throws IOException {
     return getRootDir(conf).getFileSystem(conf);
-  }
-
-  private static boolean isValidWALRootDir(Path walDir, final Configuration c) throws IOException {
-    Path rootDir = getRootDir(c);
-    FileSystem fs = walDir.getFileSystem(c);
-    Path qualifiedWalDir = walDir.makeQualified(fs.getUri(), fs.getWorkingDirectory());
-    if (!qualifiedWalDir.equals(rootDir)) {
-      if (qualifiedWalDir.toString().startsWith(rootDir.toString() + "/")) {
-        throw new IllegalStateException("Illegal WAL directory specified. " +
-            "WAL directories are not permitted to be under root directory: rootDir=" +
-            rootDir.toString() + ", qualifiedWALDir=" + qualifiedWalDir);
-      }
-    }
-    return true;
-  }
-
-  /**
-   * @param c configuration
-   * @return {@link Path} to hbase log root directory: e.g. {@value HBASE_WAL_DIR} from
-   *     configuration as a qualified Path. Defaults to HBase root dir.
-   * @throws IOException e
-   */
-  public static Path getWALRootDir(final Configuration c) throws IOException {
-    Path p = new Path(c.get(HBASE_WAL_DIR, c.get(HConstants.HBASE_DIR)));
-    if (!isValidWALRootDir(p, c)) {
-      return getRootDir(c);
-    }
-    FileSystem fs = p.getFileSystem(c);
-    return p.makeQualified(fs.getUri(), fs.getWorkingDirectory());
-  }
-
-  public static FileSystem getWALFileSystem(final Configuration c) throws IOException {
-    Path p = getWALRootDir(c);
-    FileSystem fs = p.getFileSystem(c);
-    // hadoop-core does fs caching, so need to propagate this if set
-    String enforceStreamCapability = c.get(UNSAFE_STREAM_CAPABILITY_ENFORCE);
-    if (enforceStreamCapability != null) {
-      fs.getConf().set(UNSAFE_STREAM_CAPABILITY_ENFORCE, enforceStreamCapability);
-    }
-    return fs;
   }
 
   /**

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsUtils.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsUtils.java
@@ -112,7 +112,7 @@ public final class HBCKFsUtils {
    * @return Returns the filesystem of the hbase rootdir.
    * @throws IOException from underlying FileSystem
    */
-  public static FileSystem getCurrentFileSystem(Configuration conf) throws IOException {
+  public static FileSystem getRootDirFileSystem(Configuration conf) throws IOException {
     return getRootDir(conf).getFileSystem(conf);
   }
 

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsck.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsck.java
@@ -1535,7 +1535,7 @@ public class HBaseFsck extends Configured implements Closeable {
       return;
     }
 
-    FileSystem fs = FileSystem.get(getConf());
+    FileSystem fs = FSUtils.getCurrentFileSystem(getConf());
     RegionInfo hri = HRegionFileSystem.loadRegionInfoFileContent(fs, regionDir);
     LOG.debug("RegionInfo read: " + hri.toString());
     hbi.hdfsEntry.hri = hri;
@@ -1927,7 +1927,7 @@ public class HBaseFsck extends Configured implements Closeable {
       HBaseTestingUtility.closeRegionAndWAL(meta);
       // Clean out the WAL we created and used here.
       LOG.info("Deleting {}, result={}", waldir,
-          CommonFSUtils.delete(FileSystem.get(getConf()), waldir, true));
+          CommonFSUtils.delete(FSUtils.getWALFileSystem(getConf()), waldir, true));
     }
     LOG.info("Success! hbase:meta table rebuilt. Old hbase:meta moved into " + backupDir);
     return true;
@@ -3500,7 +3500,7 @@ public class HBaseFsck extends Configured implements Closeable {
           return;
         }
 
-        FileSystem fs = FileSystem.get(conf);
+        FileSystem fs = FSUtils.getCurrentFileSystem(conf);
         LOG.info("Found parent: " + parent.getRegionNameAsString());
         LOG.info("Found potential daughter a: " + daughterA.getRegionNameAsString());
         LOG.info("Found potential daughter b: " + daughterB.getRegionNameAsString());
@@ -3624,7 +3624,7 @@ public class HBaseFsck extends Configured implements Closeable {
         }
         List<HbckInfo> regionsToSideline =
           RegionSplitCalculator.findBigRanges(bigOverlap, overlapsToSideline);
-        FileSystem fs = FileSystem.get(conf);
+        FileSystem fs = FSUtils.getCurrentFileSystem(conf);
         for (HbckInfo regionToSideline: regionsToSideline) {
           try {
             LOG.info("Closing region: " + regionToSideline);

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsck.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HBaseFsck.java
@@ -405,7 +405,7 @@ public class HBaseFsck extends Configured implements Closeable {
     lockFileRetryCounterFactory = createLockRetryCounterFactory(getConf());
     createZNodeRetryCounterFactory = createZnodeRetryCounterFactory(getConf());
     zkw = createZooKeeperWatcher();
-    rootFs = HBCKFsUtils.getCurrentFileSystem(conf);
+    rootFs = HBCKFsUtils.getRootDirFileSystem(conf);
   }
 
   /**

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
@@ -84,7 +84,7 @@ public class HFileCorruptionChecker {
   public HFileCorruptionChecker(Configuration conf, ExecutorService executor,
       boolean quarantine) throws IOException {
     this.conf = conf;
-    this.fs = FileSystem.get(conf);
+    this.fs = FSUtils.getCurrentFileSystem(conf);
     this.cacheConf = CacheConfig.DISABLED;
     this.executor = executor;
     this.inQuarantineMode = quarantine;

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
@@ -85,7 +85,7 @@ public class HFileCorruptionChecker {
   public HFileCorruptionChecker(Configuration conf, ExecutorService executor,
       boolean quarantine) throws IOException {
     this.conf = conf;
-    this.fs = HBCKFsUtils.getCurrentFileSystem(conf);
+    this.fs = HBCKFsUtils.getRootDirFileSystem(conf);
     this.cacheConf = CacheConfig.DISABLED;
     this.executor = executor;
     this.inQuarantineMode = quarantine;

--- a/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/hbck1/HFileCorruptionChecker.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.FSUtils.FamilyDirFilter;
 import org.apache.hadoop.hbase.util.FSUtils.HFileFilter;
 import org.apache.hadoop.hbase.util.FSUtils.RegionDirFilter;
+import org.apache.hbase.HBCKFsUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import org.slf4j.Logger;
@@ -84,7 +85,7 @@ public class HFileCorruptionChecker {
   public HFileCorruptionChecker(Configuration conf, ExecutorService executor,
       boolean quarantine) throws IOException {
     this.conf = conf;
-    this.fs = FSUtils.getCurrentFileSystem(conf);
+    this.fs = HBCKFsUtils.getCurrentFileSystem(conf);
     this.cacheConf = CacheConfig.DISABLED;
     this.executor = executor;
     this.inQuarantineMode = quarantine;

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
-import org.apache.hadoop.hbase.util.FSUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,7 +55,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldCreateNewTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
 
@@ -69,7 +68,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldNotCreateTheSameTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detritus laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -84,7 +83,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldAllowForcefulCreationOfAlreadyExistingTableDescriptor()
     throws Exception {
     final String name = this.name.getMethodName();
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
@@ -55,7 +55,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldCreateNewTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
 
@@ -68,7 +68,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldNotCreateTheSameTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detritus laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -83,7 +83,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldAllowForcefulCreationOfAlreadyExistingTableDescriptor()
     throws Exception {
     final String name = this.name.getMethodName();
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptorForceCreation.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +56,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldCreateNewTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
 
@@ -68,7 +69,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldNotCreateTheSameTableDescriptorIfForcefulCreationIsFalse()
     throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detritus laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -83,7 +84,7 @@ public class TestHBCKFsTableDescriptorForceCreation {
   public void testShouldAllowForcefulCreationOfAlreadyExistingTableDescriptor()
     throws Exception {
     final String name = this.name.getMethodName();
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
@@ -107,7 +107,7 @@ public class TestHBCKFsTableDescriptors {
 
   @Test public void testReadingHTDFromFS() throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();
     Path rootdir = UTIL.getDataTestDir(name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -120,7 +120,7 @@ public class TestHBCKFsTableDescriptors {
   @Test(expected = TableInfoMissingException.class)
   public void testNoSuchTable() throws IOException {
     final String name = "testNoSuchTable";
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detrius laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors htds = new HBCKFsTableDescriptors(fs, rootdir);
@@ -161,7 +161,7 @@ public class TestHBCKFsTableDescriptors {
     Path testdir = UTIL.getDataTestDir(name.getMethodName());
     final TableName name = TableName.valueOf(this.name.getMethodName());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(name).build();
-    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getRootDirFileSystem(UTIL.getConfiguration());
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, testdir);
     assertTrue(fstd.createTableDescriptor(htd, false));
     assertFalse(fstd.createTableDescriptor(htd, false));

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.FSUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,7 +107,7 @@ public class TestHBCKFsTableDescriptors {
 
   @Test public void testReadingHTDFromFS() throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();
     Path rootdir = UTIL.getDataTestDir(name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -121,7 +120,7 @@ public class TestHBCKFsTableDescriptors {
   @Test(expected = TableInfoMissingException.class)
   public void testNoSuchTable() throws IOException {
     final String name = "testNoSuchTable";
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detrius laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors htds = new HBCKFsTableDescriptors(fs, rootdir);
@@ -162,7 +161,7 @@ public class TestHBCKFsTableDescriptors {
     Path testdir = UTIL.getDataTestDir(name.getMethodName());
     final TableName name = TableName.valueOf(this.name.getMethodName());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(name).build();
-    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
+    FileSystem fs = HBCKFsUtils.getCurrentFileSystem(UTIL.getConfiguration());
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, testdir);
     assertTrue(fstd.createTableDescriptor(htd, false));
     assertFalse(fstd.createTableDescriptor(htd, false));

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKFsTableDescriptors.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,7 +108,7 @@ public class TestHBCKFsTableDescriptors {
 
   @Test public void testReadingHTDFromFS() throws IOException {
     final String name = this.name.getMethodName();
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(TableName.valueOf(name)).build();
     Path rootdir = UTIL.getDataTestDir(name);
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, rootdir);
@@ -120,7 +121,7 @@ public class TestHBCKFsTableDescriptors {
   @Test(expected = TableInfoMissingException.class)
   public void testNoSuchTable() throws IOException {
     final String name = "testNoSuchTable";
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     // Cleanup old tests if any detrius laying around.
     Path rootdir = new Path(UTIL.getDataTestDir(), name);
     HBCKFsTableDescriptors htds = new HBCKFsTableDescriptors(fs, rootdir);
@@ -161,7 +162,7 @@ public class TestHBCKFsTableDescriptors {
     Path testdir = UTIL.getDataTestDir(name.getMethodName());
     final TableName name = TableName.valueOf(this.name.getMethodName());
     TableDescriptor htd = TableDescriptorBuilder.newBuilder(name).build();
-    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    FileSystem fs = FSUtils.getCurrentFileSystem(UTIL.getConfiguration());
     HBCKFsTableDescriptors fstd = new HBCKFsTableDescriptors(fs, testdir);
     assertTrue(fstd.createTableDescriptor(htd, false));
     assertFalse(fstd.createTableDescriptor(htd, false));

--- a/hbase-hbck2/src/test/java/org/apache/hbase/hbck1/TestHBaseFsck.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/hbck1/TestHBaseFsck.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hbase.hbck1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hbase.HBCKFsUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category({MiscTests.class, SmallTests.class})
+public class TestHBaseFsck {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestHBaseFsck.class);
+
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private String defaultRootDir;
+  private String nonDefaultRootDir;
+  private FileSystem rootFs;
+  private FileSystem testFileSystem;
+  private LocalFileSystem localFileSystem;
+  private Configuration conf;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TEST_UTIL.startMiniCluster(3);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    conf = TEST_UTIL.getConfiguration();
+    // the default is a hdfs directory
+    defaultRootDir = TEST_UTIL.getDataTestDirOnTestFS().toString();
+    localFileSystem = new LocalFileSystem();
+    testFileSystem = TEST_UTIL.getTestFileSystem();
+    nonDefaultRootDir =
+        TEST_UTIL.getRandomDir().makeQualified(localFileSystem.getUri(),
+            localFileSystem.getWorkingDirectory()).toString();
+  }
+
+  @Test
+  public void testHBaseRootDirWithSameFileSystemScheme() throws IOException,
+      ClassNotFoundException {
+    checkFileSystemScheme(defaultRootDir, testFileSystem.getUri().getScheme());
+  }
+
+  @Test
+  public void testHBaseRootDirWithDifferentFileSystemScheme() throws IOException,
+      ClassNotFoundException {
+    checkFileSystemScheme(nonDefaultRootDir, localFileSystem.getUri().getScheme());
+  }
+
+  private void checkFileSystemScheme(String hbaseRootDir, String expectedFsScheme)
+      throws IOException, ClassNotFoundException {
+    conf.set(HConstants.HBASE_DIR, hbaseRootDir);
+    HBaseFsck fsck = new HBaseFsck(conf);
+    String actualFsScheme = fsck.getRootFs().getScheme();
+    assertEquals(expectedFsScheme, actualFsScheme);
+  }
+
+  @Test
+  public void testFileLockCallableWithSetHBaseRootDir() throws IOException {
+    try {
+      conf.set(HConstants.HBASE_DIR, nonDefaultRootDir);
+      HBaseFsck.FileLockCallable fileLockCallable = new HBaseFsck.FileLockCallable(conf,
+          HBaseFsck.createLockRetryCounterFactory(conf).create());
+      rootFs = fileLockCallable.getRootFs();
+      String defaultFsScheme = testFileSystem.getUri().getScheme();
+      String actualFsScheme = rootFs.getScheme();
+
+      assertEquals(localFileSystem.getUri().getScheme(), actualFsScheme);
+      assertNotEquals(testFileSystem.getUri().getScheme(), actualFsScheme);
+      // make a call and generate the hbck2 lock file to the non default file system
+      fileLockCallable.call();
+
+      Path lockFilePath = new Path(HBaseFsck.getTmpDir(conf), HBaseFsck.HBCK2_LOCK_FILE);
+      assertTrue(rootFs.exists(lockFilePath));
+      assertNotEquals(defaultFsScheme, lockFilePath.toUri().getScheme());
+    } finally {
+      HBCKFsUtils.delete(rootFs, new Path(nonDefaultRootDir), true);
+    }
+  }
+
+}

--- a/hbase-hbck2/src/test/java/org/apache/hbase/hbck1/TestHFileCorruptionChecker.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/hbck1/TestHFileCorruptionChecker.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hbase.hbck1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hbase.HBCKFsUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.mockito.Mockito;
+
+@Category({MiscTests.class, SmallTests.class})
+public class TestHFileCorruptionChecker {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestHFileCorruptionChecker.class);
+
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private String defaultRootDir;
+  private String nonDefaultRootDir;
+  private String testFsScheme;
+  private String localFsScheme;
+  private Configuration conf;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    TEST_UTIL.startMiniCluster(3);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    conf = TEST_UTIL.getConfiguration();
+    // the default is a hdfs directory
+    defaultRootDir = TEST_UTIL.getDataTestDirOnTestFS().toString();
+
+    FileSystem localFileSystem = new LocalFileSystem();
+    testFsScheme = TEST_UTIL.getTestFileSystem().getUri().getScheme();
+    localFsScheme = localFileSystem.getScheme();
+    nonDefaultRootDir =
+        TEST_UTIL.getRandomDir().makeQualified(localFileSystem.getUri(),
+            localFileSystem.getWorkingDirectory()).toString();
+  }
+
+  @Test
+  public void testCheckTableDir() throws IOException {
+    checkFileSystemScheme(defaultRootDir, testFsScheme, testFsScheme);
+  }
+
+  @Test
+  public void testCheckTableDirWithNonDefaultRootDir() throws IOException {
+    checkFileSystemScheme(nonDefaultRootDir, testFsScheme, localFsScheme);
+  }
+
+  private void checkFileSystemScheme(String hbaseRootDir, String defaultFsScheme,
+      String hbaseRootFsScheme) throws IOException {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.set(HConstants.HBASE_DIR, hbaseRootDir);
+
+    // check default filesystem, should be always hdfs
+    assertEquals(defaultFsScheme, TEST_UTIL.getTestFileSystem().getUri().getScheme());
+
+    ExecutorService mockExecutor = Mockito.mock(ExecutorService.class);
+    HFileCorruptionChecker corruptionChecker =
+        new HFileCorruptionChecker(conf, mockExecutor, true);
+    // if `FSUtils.listStatusWithStatusFilter` pass, then we're using the configured HBASE_DIR
+    corruptionChecker.checkTableDir(HBCKFsUtils.getTableDir(new Path(hbaseRootDir),
+        TableName.META_TABLE_NAME));
+
+    assertEquals(hbaseRootFsScheme, corruptionChecker.fs.getScheme());
+    if (!defaultFsScheme.equalsIgnoreCase(hbaseRootFsScheme)) {
+      assertNotEquals(TEST_UTIL.getTestFileSystem().getUri().getScheme(),
+          corruptionChecker.fs.getScheme());
+    }
+  }
+}


### PR DESCRIPTION
recently we found a bug that when running `hbck filesystem -f` on a non-HDFS and caused `Wrong FS` error and cannot move forward. 

this change fix this problem and use `FSUtils.getCurrentFileSystem` to respect the root directory of what we set with `hbase.rootdir` in stead of just using `fs.defaultFS` 