### PR TITLE
HBASE-26687 Avoid the newBuilder(RegionInfo) constructor in RegionInf…

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/RegionInfoMismatchTool.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/RegionInfoMismatchTool.java
@@ -148,11 +148,11 @@ public class RegionInfoMismatchTool {
         }
         // Third component of a region name is just a literal numeric (not a binary-encoded long)
         long regionId = Long.parseLong(Bytes.toString(regionNameParts[2]));
-        // HBASE-24500: We cannot use newBuilder(RegionInfo) because it will copy the NAME and encodedName
-        // from the original RegionInfo instead of re-computing it. Copy all of the fields by hand
-        // which will force the new RegionInfo to recompute the NAME/encodedName fields.
+        // HBASE-24500: We cannot use newBuilder(RegionInfo) because it will copy the NAME and
+        // encodedName from the original RegionInfo instead of re-computing it. Copy all of the
+        // fields by hand which will force the new RegionInfo to recompute the NAME/encodedName
+        // fields.
         RegionInfo correctedRegionInfo = RegionInfoBuilder.newBuilder(wrongRegionInfo.getTable())
-            // regionId shouldn't need to be re-set
             .setRegionId(regionId)
             .setStartKey(wrongRegionInfo.getStartKey())
             .setEndKey(wrongRegionInfo.getEndKey())

--- a/hbase-hbck2/src/main/java/org/apache/hbase/RegionInfoMismatchTool.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/RegionInfoMismatchTool.java
@@ -148,9 +148,17 @@ public class RegionInfoMismatchTool {
         }
         // Third component of a region name is just a literal numeric (not a binary-encoded long)
         long regionId = Long.parseLong(Bytes.toString(regionNameParts[2]));
-        RegionInfo correctedRegionInfo = RegionInfoBuilder.newBuilder(wrongRegionInfo)
+        // HBASE-24500: We cannot use newBuilder(RegionInfo) because it will copy the NAME and encodedName
+        // from the original RegionInfo instead of re-computing it. Copy all of the fields by hand
+        // which will force the new RegionInfo to recompute the NAME/encodedName fields.
+        RegionInfo correctedRegionInfo = RegionInfoBuilder.newBuilder(wrongRegionInfo.getTable())
+            // regionId shouldn't need to be re-set
             .setRegionId(regionId)
+            .setStartKey(wrongRegionInfo.getStartKey())
+            .setEndKey(wrongRegionInfo.getEndKey())
             .setReplicaId(0)
+            .setOffline(wrongRegionInfo.isOffline())
+            .setSplit(wrongRegionInfo.isSplit())
             .build();
 
         String rowkeyEncodedRegionName = HBCKRegionInfo.encodeRegionName(regionName);


### PR DESCRIPTION
…oMismatchTool

A previously-fixed bug in HBase might break this tool in that the new
RegionInfo built by the Tool is still incorrect because the region name
and region encoded name are not recomputed. Thankfully, the sanity check
on the tool prevented any damage from being done to hbase:meta.