### PR TITLE
HBASE-26934: Publish code coverage reports to SonarQube

### DIFF
--- a/dev-support/code-coverage/run-coverage.sh
+++ b/dev-support/code-coverage/run-coverage.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+usage() {
+  echo
+  echo "options:"
+  echo "-h     Display help"
+  echo "-u     SonarQube Host URL"
+  echo "-l     SonarQube Login Credentials"
+  echo "-k     SonarQube Project Key"
+  echo "-n     SonarQube Project Name"
+  echo
+  echo "Important:"
+  echo "    The required parameters for publishing the coverage results to SonarQube:"
+  echo "      - Host URL"
+  echo "      - Login Credentials"
+  echo "      - Project Key"
+  echo
+}
+
+execute() {
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+  MAIN_POM="${SCRIPT_DIR}/../../pom.xml"
+
+  mvn -B -e -Pclover -Psonar -f "$MAIN_POM" clean install -DskipTests -DskipShade
+
+  mvn -B -e -Pclover -f "$MAIN_POM" test -Dparallel-tests -DtestsThreadCount=8 -Dscale -fn
+
+  mvn -B -e -Pclover -f "$MAIN_POM" clover:aggregate clover:clover
+
+  # If the required parameters are given, the code coverage results are uploaded to the SonarQube Server
+  if [ -n "$SONAR_LOGIN" ] && [ -n "$SONAR_PROJECT_KEY" ] && [ -n "$SONAR_URL" ]; then
+    mvn -B -e -Psonar -f "$MAIN_POM" sonar:sonar -Dsonar.projectName="$SONAR_PROJECT_NAME" \
+      -Dsonar.host.url="$SONAR_URL" -Dsonar.login="$SONAR_LOGIN" -Dsonar.projectKey="$SONAR_PROJECT_KEY"
+  fi
+}
+
+while getopts ":u:l:k:n:h" option; do
+  case $option in
+  u) SONAR_URL=${OPTARG:-} ;;
+  l) SONAR_LOGIN=${OPTARG:-} ;;
+  k) SONAR_PROJECT_KEY=${OPTARG:-} ;;
+  n) SONAR_PROJECT_NAME=${OPTARG:-} ;;
+  h) # Display usage
+    usage
+    exit
+    ;;
+  \?) # Invalid option
+    echo "Error: Invalid option"
+    exit
+    ;;
+  esac
+done
+
+# Start code analysis
+execute

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,9 @@
     <enforcer.version>3.0.0-M2</enforcer.version>
     <extra.enforcer.version>1.0-beta-9</extra.enforcer.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
+    <!--code coverage properties-->
+    <clover-maven-plugin.version>4.4.1</clover-maven-plugin.version>
+    <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -468,6 +471,97 @@
             </configuration>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>clover</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>clover</name>
+        </property>
+      </activation>
+      <properties>
+        <cloverDatabase>${project.build.directory}/clover/code-coverage.db</cloverDatabase>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openclover</groupId>
+            <artifactId>clover-maven-plugin</artifactId>
+            <configuration>
+              <cloverDatabase>${cloverDatabase}</cloverDatabase>
+              <cloverMergeDatabase>${cloverDatabase}</cloverMergeDatabase>
+              <outputDirectory>${project.build.directory}/clover</outputDirectory>
+              <targetPercentage>50%</targetPercentage>
+              <alwaysReport>true</alwaysReport>
+              <generateHistorical>false</generateHistorical>
+              <generateHtml>true</generateHtml>
+              <generateXml>true</generateXml>
+              <includesTestSourceRoots>true</includesTestSourceRoots>
+              <includesAllSourceRoots>false</includesAllSourceRoots>
+              <includes>
+                <include>**/org/apache/**/*.java</include>
+              </includes>
+              <excludes>
+                <exclude>**/src/main/assembly/**/*</exclude>
+                <exclude>hbase-operator-tools-assembly/**/*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>clover-setup</id>
+                <goals>
+                  <goal>setup</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.openclover</groupId>
+              <artifactId>clover-maven-plugin</artifactId>
+              <version>${clover-maven-plugin.version}</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>sonar</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>sonar</name>
+        </property>
+      </activation>
+      <properties>
+        <sonar.core.codeCoveragePlugin>clover</sonar.core.codeCoveragePlugin>
+        <sonar.clover.version>${clover-maven-plugin.version}</sonar.clover.version>
+        <sonar.clover.reportPath>${project.build.directory}/clover/clover.xml</sonar.clover.reportPath>
+        <sonar.surefire.reportsPath>${project.build.directory}/surefire-reports</sonar.surefire.reportsPath>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.exclusions>hbase-operator-tools-assembly/**/*,**/pom.xml</sonar.exclusions>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.sonarsource.scanner.maven</groupId>
+              <artifactId>sonar-maven-plugin</artifactId>
+              <version>${sonar-maven-plugin.version}</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
The newly added script runs maven with the clover profile which generates the test coverage data. 
If the necessary parameters are given it also uploads the results to SonarQube.

The required parameters for publishing to SonarQube are:

- Host URL
- Login Credentials
- Project Key

Example commands:

- Run clover code analysis (without publishing to SonarQube)
`sh dev-support/code-coverage/run-coverage.sh`

- Run clover code analysis and publish the results to SonarQube
`sh dev-support/code-coverage/run-coverage.sh -l ProjectCredentials -u https://exampleserver.com -k Project_Key -n Project_Name`