### PR TITLE
HBASE-27119 [HBCK2] Some commands are broken after HBASE-24587

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -1070,8 +1070,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
         try (ClusterConnection connection = connect()) {
           checkHBCKSupport(connection, command);
           try (FileSystemFsck fsfsck = new FileSystemFsck(getConf())) {
-            return fsfsck.fsck(getInputList(purgeFirst(commands))
-                    .toArray(new String[0])) != 0? EXIT_FAILURE : EXIT_SUCCESS;
+            return fsfsck.fsck(purgeFirst(commands)) != 0? EXIT_FAILURE : EXIT_SUCCESS;
           }
         }
 
@@ -1079,8 +1078,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
         try (ClusterConnection connection = connect()) {
           checkHBCKSupport(connection, command, "2.1.1", "2.2.0", "3.0.0");
           try (ReplicationFsck replicationFsck = new ReplicationFsck(getConf())) {
-            return replicationFsck.fsck(getInputList(purgeFirst(commands))
-                    .toArray(new String[0])) != 0? EXIT_FAILURE : EXIT_SUCCESS;
+            return replicationFsck.fsck(purgeFirst(commands)) != 0? EXIT_FAILURE : EXIT_SUCCESS;
           }
         }
 
@@ -1363,7 +1361,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
   /**
    * @return Read arguments from args or a list of input files
    */
-  private List<String> getFromArgsOrFiles(List<String> args, boolean getFromFile)
+  public static List<String> getFromArgsOrFiles(List<String> args, boolean getFromFile)
           throws IOException {
     if (!getFromFile || args == null) {
       return args;
@@ -1374,7 +1372,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
   /**
    * @return Read arguments from a list of input files
    */
-  private List<String> getFromFiles(List<String> args) throws IOException {
+  private static List<String> getFromFiles(List<String> args) throws IOException {
     List<String> argList = new ArrayList<>();
     for (String filePath : args) {
       try (InputStream fileStream = new FileInputStream(filePath)){

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
@@ -187,8 +187,8 @@ public class TestHBCKCommandLineParsing {
     File input = null;
     try {
       input = createInputFile();
-      String output =
-              retrieveOptionOutput(new String[] { "replication", "-f", "--inputFiles", input.getPath() });
+      String output = retrieveOptionOutput(new String[] { "replication", "-f",
+              "--inputFiles", input.getPath() });
       assertTrue(
               output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
       assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
@@ -309,8 +309,8 @@ public class TestHBCKCommandLineParsing {
     File input = null;
     try {
       input = createInputFile();
-      String output =
-              retrieveOptionOutput(new String[] { "filesystem", "-f", "--inputFiles", input.getPath() });
+      String output = retrieveOptionOutput(new String[] { "filesystem", "-f", "--inputFiles",
+              input.getPath() });
       assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
       assertTrue(output.indexOf("ERROR: Unrecognized option: --inputFiles") < 0);
     } finally {

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
@@ -20,10 +20,14 @@ package org.apache.hbase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.util.Properties;
 
@@ -65,7 +69,7 @@ public class TestHBCKCommandLineParsing {
     assertTrue(output, output.startsWith("usage: HBCK2"));
 
     // Passing -h/--help does the same
-    output = retrieveOptionOutput("-h");
+    output = retrieveOptionOutput(new String[]{ "-h" });
     assertTrue(output, output.startsWith("usage: HBCK2"));
   }
 
@@ -75,7 +79,7 @@ public class TestHBCKCommandLineParsing {
     String[] cmds = new String[]{"setTableState", "bypass", "scheduleRecoveries"};
     String output;
     for(String cmd: cmds){
-      output = retrieveOptionOutput(cmd);
+      output = retrieveOptionOutput(new String[]{ cmd });
       assertTrue(output, output.startsWith("ERROR: "));
       assertTrue(output, output.contains("FOR USAGE, use the -h or --help option"));
     }
@@ -108,17 +112,260 @@ public class TestHBCKCommandLineParsing {
     properties.load(inputStream);
     String expectedVersionOutput = properties.getProperty("version");
     // Get hbck version option output.
-    String actualVersionOutput = retrieveOptionOutput("-v").trim();
+    String actualVersionOutput = retrieveOptionOutput(new String[]{ "-v" }).trim();
     assertEquals(expectedVersionOutput, actualVersionOutput);
   }
 
-  private String retrieveOptionOutput(String option) throws IOException {
+  @Test
+  public void testReplicationNoOption() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"replication"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+  }
+
+  @Test
+  public void testReplicationFixShortOption() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"replication",  "-f"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+  }
+
+  @Test
+  public void testReplicationFixShortOptionTable() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"replication",  "-f", "table"});
+    assertTrue(
+            output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+    assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+  }
+
+  @Test
+  public void testReplicationFixShortOptionInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "-f", "-i", input.getPath() });
+      assertTrue(
+              output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testReplicationFixLongOption() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"replication",  "--fix"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+  }
+
+  @Test
+  public void testReplicationFixLongOptionTable() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"replication",  "--fix", "table"});
+    assertTrue(
+            output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+    assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+  }
+
+  @Test
+  public void testReplicationFixLongOptionInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "--fix", "-i", input.getPath() });
+      assertTrue(
+              output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testReplicationFixShortOptionInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "-f", "--inputFiles", input.getPath() });
+      assertTrue(
+              output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inputFiles") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testReplicationFixLongOptionInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "--fix", "--inputFiles",
+                      input.getPath() });
+      assertTrue(
+              output.indexOf("ERROR: No replication barrier(s) on table: table\n") >= 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inoutFiles") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testReplicationInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "--inputFiles", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inputFiles") < 0);
+
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testReplicationInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "replication", "-i", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  private File createInputFile() throws Exception {
+    File f = new File("input");
+    try(BufferedWriter writer = new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(f)))) {
+      writer.write("table");
+      writer.flush();
+    }
+    return f;
+  }
+
+  @Test
+  public void testFilesystemFixShortOption() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"filesystem",  "-f"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+  }
+
+  @Test
+  public void testFilesystemFixShortOptionTable() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"filesystem",  "-f", "table"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+  }
+
+  @Test
+  public void testFilesystemFixShortOptionInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "-f", "-i", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testFilesystemFixLongOption() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"filesystem",  "--fix"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+  }
+
+  @Test
+  public void testFilesystemFixLongOptionTable() throws IOException {
+    String output = retrieveOptionOutput(new String[]{"filesystem",  "--fix", "table"});
+    assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+  }
+
+  @Test
+  public void testFilesystemFixLongOptionInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "--fix", "-i", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testFilesystemFixShortOptionInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "-f", "--inputFiles", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -f") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inputFiles") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testFilesystemFixLongOptionInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "--fix", "--inputFiles",
+                      input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --fix") < 0);
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inoutFiles") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testFilesystemInputFileLong() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "--inputFiles", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: --inputFiles") < 0);
+
+    } finally {
+      input.delete();
+    }
+  }
+
+  @Test
+  public void testFilesystemInputFile() throws Exception {
+    File input = null;
+    try {
+      input = createInputFile();
+      String output =
+              retrieveOptionOutput(new String[] { "filesystem", "-i", input.getPath() });
+      assertTrue(output.indexOf("ERROR: Unrecognized option: -i") < 0);
+    } finally {
+      input.delete();
+    }
+  }
+  private String retrieveOptionOutput(String[] options) throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(os);
     PrintStream oldOut = System.out;
     System.setOut(stream);
-    if (option != null) {
-      this.hbck2.run(new String[] { option });
+    if (options != null) {
+      this.hbck2.run(options);
     } else {
       this.hbck2.run(null);
     }


### PR DESCRIPTION
For review only. This is an alternative implementation of fix to https://github.com/apache/hbase-operator-tools/pull/107

HBASE-24587 implemented command options separately for every command. For two commands, the order was wrong. Other commands such as bypass and assigns are OK. This fix follows the same pattern of other commands with command options.