### PR TITLE
HBASE-27751 TestMissingTableDescriptorGenerator fails with HBase 2.5.3

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsTableDescriptors.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCKFsTableDescriptors.java
@@ -211,12 +211,12 @@ public class HBCKFsTableDescriptors  {
   }
 
   /**
-   * Regex to eat up sequenceid suffix on a .tableinfo file.
+   * Regex to eat up sequenceid suffix and file size suffix on a .tableinfo file.
    * Use regex because may encounter oldstyle .tableinfos where there is no
-   * sequenceid on the end.
+   * sequenceid nor filesize at the end.
    */
-  private static final Pattern TABLEINFO_FILE_REGEX =
-    Pattern.compile(TABLEINFO_FILE_PREFIX + "(\\.([0-9]{" + WIDTH_OF_SEQUENCE_ID + "}))?$");
+  private static final Pattern TABLEINFO_FILE_REGEX = Pattern.compile(
+      TABLEINFO_FILE_PREFIX + "(\\.([0-9]{" + WIDTH_OF_SEQUENCE_ID + "}))?" + "(\\.([0-9]+))?$");
 
   /**
    * @param p Path to a <code>.tableinfo</code> file.
@@ -439,7 +439,6 @@ public class HBCKFsTableDescriptors  {
     Path p = writeTableDescriptor(fs, htd, tableDir, status);
     return p != null;
   }
-
 }
 
 


### PR DESCRIPTION
Ran following commands and ensured no tests fail with the change:
```
mvn clean install 
mvn clean install -Dhbase.version=2.5.3 -Dhbase-thirdparty.version=4.1.4
```
Old Regex:  `.tableinfo(\.([0-9]{10}))?$`
New Regex: `.tableinfo(\.([0-9]{10}))?(\.([0-9]+))?$`