### PR TITLE
HBASE-27961 Running assigns/unassigns command with large number of files/regions throws CallTimeoutException

### DIFF
--- a/hbase-hbck2/README.md
+++ b/hbase-hbck2/README.md
@@ -160,7 +160,9 @@ Command:
    If -b or --batchSize is specified, the command processes those many
    regions at a time in a batch-ed manner; Consider using this option,
    if the list of regions is huge, to avoid CallTimeoutException.
+   For example:
      $ HBCK2 assigns -i fileName1 fileName2 -b 500
+   By default, batchSize is set to -1 i.e. no batching is done.
 
  bypass [OPTIONS] [<PID>...|-i <INPUT_FILE>...]
    Options:
@@ -168,7 +170,7 @@ Command:
     -r,--recursive  bypass parent and its children. SLOW! EXPENSIVE!
     -w,--lockWait   milliseconds to wait before giving up; default=1
     -i,--inputFiles  take one or more input files of PID's
-    -b,--batchSize   number of procedure to process in a batch
+    -b,--batchSize   number of procedures to process in a batch
    Pass one (or more) procedure 'pid's to skip to procedure finish. Parent
    of bypassed procedure will also be skipped to the finish. Entities will
    be left in an inconsistent state and will require manual fixup. May
@@ -182,7 +184,9 @@ Command:
    If -b or --batchSize is specified, the command processes those many
    procedures at a time in a batch-ed manner; Consider using this option,
    if the list of procedures is huge, to avoid CallTimeoutException.
+   For example:
      $ HBCK2 bypass -i fileName1 fileName2 -b 500
+   By default, batchSize is set to -1 i.e. no batching is done.
 
  extraRegionsInMeta [<NAMESPACE|NAMESPACE:TABLENAME>...|
       -i <INPUT_FILE>...]
@@ -416,7 +420,9 @@ Command:
    If -b or --batchSize is specified, the tool processes those many
    regions at a time in a batch-ed manner; Consider using this option,
    if the list of regions is huge, to avoid CallTimeoutException.
+   For example:
      $ HBCK2 unassigns -i fileName1 fileName2 -b 500
+   By default, batchSize is set to -1 i.e. no batching is done.
 
 ```
 Note that when you pass `bin/hbase` the `hbck` argument, it will by

--- a/hbase-hbck2/README.md
+++ b/hbase-hbck2/README.md
@@ -146,6 +146,7 @@ Command:
    Options:
     -o,--override  override ownership by another procedure
     -i,--inputFiles  take one or more files of encoded region names
+    -b,--batchSize   number of regions to process in a batch
    A 'raw' assign that can be used even during Master initialization (if
    the -skip flag is specified). Skirts Coprocessors. Pass one or more
    encoded region names. 1588230740 is the hard-coded name for the
@@ -156,6 +157,10 @@ Command:
    If -i or --inputFiles is specified, pass one or more input file names.
    Each file contains encoded region names, one per line. For example:
      $ HBCK2 assigns -i fileName1 fileName2
+   If -b or --batchSize is specified, the command processes those many
+   regions at a time in a batch-ed manner; Consider using this option,
+   if the list of regions is huge, to avoid CallTimeoutException.
+     $ HBCK2 assigns -i fileName1 fileName2 -b 500
 
  bypass [OPTIONS] [<PID>...|-i <INPUT_FILE>...]
    Options:
@@ -163,6 +168,7 @@ Command:
     -r,--recursive  bypass parent and its children. SLOW! EXPENSIVE!
     -w,--lockWait   milliseconds to wait before giving up; default=1
     -i,--inputFiles  take one or more input files of PID's
+    -b,--batchSize   number of procedure to process in a batch
    Pass one (or more) procedure 'pid's to skip to procedure finish. Parent
    of bypassed procedure will also be skipped to the finish. Entities will
    be left in an inconsistent state and will require manual fixup. May
@@ -173,6 +179,10 @@ Command:
    If -i or --inputFiles is specified, pass one or more input file names.
    Each file contains PID's, one per line. For example:
      $ HBCK2 bypass -i fileName1 fileName2
+   If -b or --batchSize is specified, the command processes those many
+   procedures at a time in a batch-ed manner; Consider using this option,
+   if the list of procedures is huge, to avoid CallTimeoutException.
+     $ HBCK2 bypass -i fileName1 fileName2 -b 500
 
  extraRegionsInMeta [<NAMESPACE|NAMESPACE:TABLENAME>...|
       -i <INPUT_FILE>...]
@@ -385,10 +395,11 @@ Command:
    Each file contains <SERVERNAME>, one per line. For example:
      $ HBCK2 scheduleRecoveries -i fileName1 fileName2
 
- unassigns [<ENCODED_REGIONNAME>...|-i <INPUT_FILE>...]
+ unassigns [OPTIONS] [<ENCODED_REGIONNAME>...|-i <INPUT_FILE>...]
    Options:
     -o,--override  override ownership by another procedure
     -i,--inputFiles  take one or more input files of encoded region names
+    -b,--batchSize   number of regions to process in a batch
    A 'raw' unassign that can be used even during Master initialization
    (if the -skip flag is specified). Skirts Coprocessors. Pass one or
    more encoded region names. 1588230740 is the hard-coded name for the
@@ -402,6 +413,10 @@ Command:
    If -i or --inputFiles is specified, pass one or more input file names.
    Each file contains encoded region names, one per line. For example:
      $ HBCK2 unassigns -i fileName1 fileName2
+   If -b or --batchSize is specified, the tool processes those many
+   regions at a time in a batch-ed manner; Consider using this option,
+   if the list of regions is huge, to avoid CallTimeoutException.
+     $ HBCK2 unassigns -i fileName1 fileName2 -b 500
 
 ```
 Note that when you pass `bin/hbase` the `hbck` argument, it will by

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -137,12 +137,12 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
   private static final long DEFAULT_LOCK_WAIT = 1;
 
   /**
-   * Value which would represent no batching.
+   * Value which represents no batching.
    */
   private static final int NO_BATCH_SIZE = -1;
 
   /**
-   * Number of units to process in a single call. By default, it is set to -1, that is no batching
+   * Number of batches to process in a single call. By default, it is set to -1, that is no batching
    * would be done.
    */
   private static final int DEFAULT_BATCH_SIZE = NO_BATCH_SIZE;
@@ -489,7 +489,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
       List<Long> pidList = new ArrayList<>(regionList.size());
       final List<List<String>> batch = Lists.partition(regionList, batchSize);
       for (int i = 0; i < batch.size(); i++) {
-        LOG.info("Processing batch #" + i);
+        LOG.info("Processing batch #{}", i + 1);
         pidList.addAll(hbck.assigns(batch.get(i), overrideFlag));
       }
       return pidList;
@@ -525,7 +525,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
       List<Long> pidList = new ArrayList<>(regionList.size());
       final List<List<String>> batch = Lists.partition(regionList, batchSize);
       for (int i = 0; i < batch.size(); i++) {
-        LOG.info("Processing batch #" + i);
+        LOG.info("Processing batch #{}", i + 1);
         pidList.addAll(hbck.unassigns(batch.get(i), overrideFlag));
       }
       return pidList;
@@ -579,7 +579,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
         List<Boolean> statusList = new ArrayList<>(pids.size());
         final List<List<Long>> batch = Lists.partition(pids, batchSize);
         for (int i = 0; i < batch.size(); i++) {
-          LOG.info("Processing batch #" + i);
+          LOG.info("Processing batch #{}", i + 1);
           statusList
             .addAll(hbck.bypassProcedure(batch.get(i), lockWait, overrideFlag, recursiveFlag));
         }

--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -480,14 +480,13 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     boolean overrideFlag = commandLine.hasOption(override.getOpt());
     boolean inputFileFlag = commandLine.hasOption(inputFile.getOpt());
 
-    List<String> argList = commandLine.getArgList();
-    List<String> regionList = getFromArgsOrFiles(argList, inputFileFlag);
+    List<String> regionList = getFromArgsOrFiles(commandLine.getArgList(), inputFileFlag);
 
     // Process here
     if (batchSize == NO_BATCH_SIZE) {
       return hbck.assigns(regionList, overrideFlag);
     } else {
-      List<Long> pidList = new ArrayList<>(argList.size());
+      List<Long> pidList = new ArrayList<>(regionList.size());
       final List<List<String>> batch = Lists.partition(regionList, batchSize);
       for (int i = 0; i < batch.size(); i++) {
         LOG.info("Processing batch #" + i);
@@ -517,14 +516,13 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     boolean inputFileFlag = commandLine.hasOption(inputFile.getOpt());
     int batchSize = getBatchSize(batchOpt, commandLine);
 
-    List<String> argList = commandLine.getArgList();
-    List<String> regionList = getFromArgsOrFiles(argList, inputFileFlag);
+    List<String> regionList = getFromArgsOrFiles(commandLine.getArgList(), inputFileFlag);
 
     // Process here
     if (batchSize == NO_BATCH_SIZE) {
       return hbck.unassigns(regionList, overrideFlag);
     } else {
-      List<Long> pidList = new ArrayList<>(argList.size());
+      List<Long> pidList = new ArrayList<>(regionList.size());
       final List<List<String>> batch = Lists.partition(regionList, batchSize);
       for (int i = 0; i < batch.size(); i++) {
         LOG.info("Processing batch #" + i);
@@ -744,7 +742,9 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     writer.println("   If -b or --batchSize is specified, the command processes those many");
     writer.println("   regions at a time in a batch-ed manner; Consider using this option,");
     writer.println("   if the list of regions is huge, to avoid CallTimeoutException.");
+    writer.println("   For example:");
     writer.println("     $ HBCK2 " + ASSIGNS + " -i fileName1 fileName2 -b 500");
+    writer.println("   By default, batchSize is set to -1 i.e. no batching is done.");
   }
 
   private static void usageBypass(PrintWriter writer) {
@@ -754,7 +754,7 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     writer.println("    -r,--recursive  bypass parent and its children. SLOW! EXPENSIVE!");
     writer.println("    -w,--lockWait   milliseconds to wait before giving up; default=1");
     writer.println("    -i,--inputFiles  take one or more input files of PID's");
-    writer.println("    -b,--batchSize   number of procedure to process in a batch");
+    writer.println("    -b,--batchSize   number of procedures to process in a batch");
     writer.println("   Pass one (or more) procedure 'pid's to skip to procedure finish. Parent");
     writer.println("   of bypassed procedure will also be skipped to the finish. Entities will");
     writer.println("   be left in an inconsistent state and will require manual fixup. May");
@@ -768,7 +768,9 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     writer.println("   If -b or --batchSize is specified, the command processes those many");
     writer.println("   procedures at a time in a batch-ed manner; Consider using this option,");
     writer.println("   if the list of procedures is huge, to avoid CallTimeoutException.");
+    writer.println("   For example:");
     writer.println("     $ HBCK2 " + BYPASS + " -i fileName1 fileName2 -b 500");
+    writer.println("   By default, batchSize is set to -1 i.e. no batching is done.");
   }
 
   private static void usageFilesystem(PrintWriter writer) {
@@ -1007,7 +1009,9 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
     writer.println("   If -b or --batchSize is specified, the tool processes those many");
     writer.println("   regions at a time in a batch-ed manner; Consider using this option,");
     writer.println("   if the list of regions is huge, to avoid CallTimeoutException.");
+    writer.println("   For example:");
     writer.println("     $ HBCK2 " + UNASSIGNS + " -i fileName1 fileName2 -b 500");
+    writer.println("   By default, batchSize is set to -1 i.e. no batching is done.");
   }
 
   private static void usageRegioninfoMismatch(PrintWriter writer) {

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCK2.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCK2.java
@@ -63,6 +63,12 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.DefaultParser;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Option;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.Options;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.ParseException;
+
 /**
  * Tests commands. For command-line parsing, see adjacent test.
  * @see TestHBCKCommandLineParsing
@@ -769,5 +775,31 @@ public class TestHBCK2 {
     for (boolean rs : result) {
       assertFalse(rs);
     }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingOfBatchSizeWithInvalidDatatype() throws Exception {
+    String value = "2A";
+    parseAndGetBatchSize(value);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingOfBatchSizeWithInvalidValue() throws Exception {
+    parseAndGetBatchSize("-2");
+  }
+
+  @Test
+  public void testParsingOfBatchSize() throws Exception {
+    assertEquals(200, parseAndGetBatchSize("200"));
+  }
+
+  private int parseAndGetBatchSize(String value) throws ParseException {
+    Options options = new Options();
+    Option batchOpt = Option.builder("b").longOpt("batchSize").hasArg().type(Integer.class).build();
+    options.addOption(batchOpt);
+
+    CommandLine commandLine =
+      new DefaultParser().parse(options, new String[] { "-b", value }, false);
+    return HBCK2.getBatchSize(batchOpt, commandLine);
   }
 }

--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
@@ -365,4 +365,14 @@ public class TestHBCKCommandLineParsing {
     System.setOut(oldOut);
     return os.toString();
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAssignsParsingOfBatchSizeWithInvalidDatatype() throws Exception {
+    retrieveOptionOutput(new String[] { "assigns", "-b", "2A", "r1", "r2", "r3" });
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUnassignsParsingOfBatchSizeWithInvalidValue() throws Exception {
+    retrieveOptionOutput(new String[] { "unassigns", "-b", "-2", "r1", "r2", "r3" });
+  }
 }


### PR DESCRIPTION
- Add supports for batching in following commands: assigns, unassigns and bypass
- Update the command help appropriately
- Sync README.md with updated command help
- Also dropped dead code `parseAndGetCommandLineWithInputOption`