### PR TITLE
HBASE-28253: HBCK2 filesystem command to fix version file fails when Master in not up.

### DIFF
--- a/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
+++ b/hbase-hbck2/src/main/java/org/apache/hbase/HBCK2.java
@@ -1220,15 +1220,12 @@ public class HBCK2 extends Configured implements org.apache.hadoop.util.Tool {
         }
 
       case FILESYSTEM:
-        try (ClusterConnection connection = connect()) {
-          checkHBCKSupport(connection, command);
-          try (FileSystemFsck fsfsck = new FileSystemFsck(getConf())) {
-            Pair<CommandLine, List<String>> pair =
-              parseCommandWithFixAndInputOptions(purgeFirst(commands));
-            return fsfsck.fsck(pair.getSecond(), pair.getFirst().hasOption("f")) != 0
-              ? EXIT_FAILURE
-              : EXIT_SUCCESS;
-          }
+        try (FileSystemFsck fsfsck = new FileSystemFsck(getConf())) {
+          Pair<CommandLine, List<String>> pair =
+            parseCommandWithFixAndInputOptions(purgeFirst(commands));
+          return fsfsck.fsck(pair.getSecond(), pair.getFirst().hasOption("f")) != 0
+            ? EXIT_FAILURE
+            : EXIT_SUCCESS;
         }
 
       case REPLICATION:


### PR DESCRIPTION
Removed the check for HBCK support in the filesystem command as it causes issues while trying to run command filesystem -f which doesn't need master to be up. Filesystem checks are all offline and doesn't need the master.