### PR TITLE
HBASE-28532 Remove vulnerable dependencies: slf4j-log4j12 and log4j:log4j

### DIFF
--- a/hbase-hbck2/pom.xml
+++ b/hbase-hbck2/pom.xml
@@ -68,6 +68,12 @@
       <artifactId>hbase-server</artifactId>
       <version>${hbase.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -75,6 +81,12 @@
       <version>${hbase.version}</version>
       <type>test-jar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -82,6 +94,12 @@
       <version>${hbase.version}</version>
       <type>test-jar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -89,6 +107,12 @@
       <version>${hbase.version}</version>
       <type>test-jar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-table-reporter/pom.xml
+++ b/hbase-table-reporter/pom.xml
@@ -42,17 +42,23 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.25</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.25</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
       <version>${hbase.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.datasketches</groupId>

--- a/hbase-tools/pom.xml
+++ b/hbase-tools/pom.xml
@@ -58,12 +58,24 @@
       <artifactId>hbase-server</artifactId>
       <version>${hbase.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>
       <version>${hbase.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -71,6 +83,12 @@
       <version>${hbase.version}</version>
       <type>test-jar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -78,6 +96,12 @@
       <version>${hbase.version}</version>
       <type>test-jar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,8 @@
     <spotless.version>2.27.2</spotless.version>
     <hbase.version>2.4.4</hbase.version>
     <hbase-thirdparty.version>2.2.1</hbase-thirdparty.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.17.2</log4j2.version>
+    <slf4j.version>1.7.33</slf4j.version>
     <surefire.provider>surefire-junit47</surefire.provider>
     <test.output.tofile>true</test.output.tofile>
     <checkstyle.version>8.45.1</checkstyle.version>


### PR DESCRIPTION
Removed all deps of log4j 1.x which is vulnerable
Build and tests are passing 
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache HBase Operator Tools 1.3.0-SNAPSHOT:
[INFO] 
[INFO] Apache HBase Operator Tools ........................ SUCCESS [  2.353 s]
[INFO] Apache HBase - Table Reporter ...................... SUCCESS [ 12.604 s]
[INFO] Apache HBase - HBCK2 ............................... SUCCESS [ 13.915 s]
[INFO] Apache HBase - HBase Tools ......................... SUCCESS [  5.482 s]
[INFO] Apache HBase Operator Tools - Assembly ............. SUCCESS [  0.188 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  34.954 s
[INFO] Finished at: 2024-08-08T20:18:15Z
[INFO] ------------------------------------------------------------------------
```