### PR TITLE
HBASE-28632 Make -h arg respected by hbck2 and exit if unrecognized arguments are passed

### DIFF
--- a/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
+++ b/hbase-hbck2/src/test/java/org/apache/hbase/TestHBCKCommandLineParsing.java
@@ -72,6 +72,15 @@ public class TestHBCKCommandLineParsing {
     // Passing -h/--help does the same
     output = retrieveOptionOutput(new String[] { "-h" });
     assertTrue(output, output.startsWith("usage: HBCK2"));
+
+    // passing -h after the command, should print usage for that command
+    output = retrieveOptionOutput(new String[] { "addFsRegionsMissingInMeta", "-h" });
+    assertFalse(output.contains("ERROR:"));
+    assertTrue(output.contains("Options:"));
+
+    // invalid argument -h should print error
+    output = retrieveOptionOutput(new String[] { "invalidArg", "-h" });
+    assertTrue(output.contains("ERROR:"));
   }
 
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28632


The commands in hbck2 do not accept `-h` in order to display the usage guide. Adding that functionality with this PR. Before the command is performed, the `-h` option is checked and if it exists, then the command specific usage guide is printed. 


### Example command 

`addFsRegionsMissingInMeta -h`


### Example output

````
usage: HBCK2 [OPTIONS] COMMAND <ARGS>
Options:
 -d,--debug                                       run with debug output
 -h,--help                                        output this help message
 -p,--hbase.zookeeper.property.clientPort <arg>   port of hbase ensemble
 -q,--hbase.zookeeper.quorum <arg>                hbase ensemble
 -s,--skip                                        skip hbase version check
                                                  (PleaseHoldException)
 -v,--version                                     this hbck2 version
 -z,--zookeeper.znode.parent <arg>                parent znode of hbase
                                                  ensemble
Command:
 addFsRegionsMissingInMeta [OPTIONS]
      [<NAMESPACE|NAMESPACE:TABLENAME>...|-i <INPUTFILES>...]
   Options:
    -i,--inputFiles  take one or more files of namespace or table names
    -o,--outputFile  name/prefix of the file(s) to dump region names
    -n,--numLines  number of lines to be written to each output file
   To be used when regions missing from hbase:meta but directories
   are present still in HDFS. Can happen if user has run _hbck1_
   'OfflineMetaRepair' against an hbase-2.x cluster. Needs hbase:meta
   to be online. For each table name passed as parameter, performs diff
   between regions available in hbase:meta and region dirs on HDFS.
   Then for dirs with no hbase:meta matches, it reads the 'regioninfo'
   metadata file and re-creates given region in hbase:meta. Regions are
   re-created in 'CLOSED' state in the hbase:meta table, but not in the
   Masters' cache, and they are not assigned either. To get these
   regions online, run the HBCK2 'assigns'command printed when this
   command-run completes.
   NOTE: If using hbase releases older than 2.3.0, a rolling restart of
   HMasters is needed prior to executing the set of 'assigns' output.
   An example adding missing regions for tables 'tbl_1' in the default
   namespace, 'tbl_2' in namespace 'n1' and for all tables from
   namespace 'n2':
     $ HBCK2 addFsRegionsMissingInMeta default:tbl_1 n1:tbl_2 n2
   Returns HBCK2  an 'assigns' command with all re-inserted regions.
   SEE ALSO: reportMissingRegionsInMeta
   SEE ALSO: fixMeta
   If -i or --inputFiles is specified, pass one or more input file names.
   Each file contains <NAMESPACE|NAMESPACE:TABLENAME>, one per line.
   For example:
     $ HBCK2 addFsRegionsMissingInMeta -i fileName1 fileName2
   If -o or --outputFile is specified, the output file(s) can be passed as
    input to assigns command via -i or -inputFiles option.
   If -n or --numLines is specified, and say it is  set to 100, this will
   create files with prefix as value passed by -o or --outputFile option.
   Each file will have 100 region names (max.), one per line.
   For example:
     $ HBCK2 addFsRegionsMissingInMeta -o outputFilePrefix -n 100
     -i fileName1 fileName2
   But if -n is not specified, but -o is specified, it will dump all
   region names in a single file, one per line.
   NOTE: -n option is applicable only if -o option is specified.



````


@ndimiduk @bbeaudreault @rmdmattingly