### PR TITLE
HBASE-28768 hbase-table-reporter shoud use the hbase.version declared in the parent pom.xml and use junit for UT

### DIFF
--- a/hbase-table-reporter/pom.xml
+++ b/hbase-table-reporter/pom.xml
@@ -34,6 +34,12 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.25</version>
@@ -46,7 +52,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
-      <version>2.1.1</version>
+      <version>${hbase.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.datasketches</groupId>

--- a/hbase-table-reporter/src/test/java/org/apache/hbase/reporter/TestTableReporter.java
+++ b/hbase-table-reporter/src/test/java/org/apache/hbase/reporter/TestTableReporter.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hbase.reporter;
 
-import static org.apache.hadoop.hbase.shaded.junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Details see : [HBASE-28768](https://issues.apache.org/jira/browse/HBASE-28768)

Related discussions： #142


**Self testing：**
```shell
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hbase.reporter.TestTableReporter
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.06 s - in org.apache.hbase.reporter.TestTableReporter
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache HBase Operator Tools 1.3.0-SNAPSHOT:
[INFO] 
[INFO] Apache HBase Operator Tools ........................ SUCCESS [  1.103 s]
[INFO] Apache HBase - Table Reporter ...................... SUCCESS [  2.663 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.948 s
```

**Building:**  
```shell
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache HBase Operator Tools 1.3.0-SNAPSHOT:
[INFO] 
[INFO] Apache HBase Operator Tools ........................ SUCCESS [  1.602 s]
[INFO] Apache HBase - Table Reporter ...................... SUCCESS [  8.034 s]
[INFO] Apache HBase - HBCK2 ............................... SUCCESS [  6.227 s]
[INFO] Apache HBase - HBase Tools ......................... SUCCESS [  1.398 s]
[INFO] Apache HBase Operator Tools - Assembly ............. SUCCESS [  0.047 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.472 s
```